### PR TITLE
Provide an environment variable to override compile-time shader path

### DIFF
--- a/shader.cc
+++ b/shader.cc
@@ -1,6 +1,6 @@
 /* shader.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Sep 2017, 18:02:33 tquirk
+ *   last updated 11 Oct 2017, 17:12:10 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -27,6 +27,7 @@
  *
  */
 
+#include <stdlib.h>
 #include <string.h>
 
 #include <string>
@@ -40,16 +41,34 @@
 
 #include "shader.h"
 
+static std::string default_shader_path = SHADER_SRC_PATH;
+
+std::string shader_path(void)
+{
+    char *env_path = getenv("CUDDLY_SHADER_PATH");
+    std::string fname;
+
+    if (env_path != NULL)
+        fname = env_path;
+    else
+        fname = default_shader_path;
+
+    if (fname.find_last_of('/') != fname.size() - 1)
+        fname += "/";
+    return fname;
+}
+
 GLuint load_shader(GLenum type, const std::string& file)
 {
     std::string src;
-    std::ifstream infile(file, std::ios::in | std::ios::binary);
+    std::string fname = shader_path() + file;
+    std::ifstream infile(fname, std::ios::in | std::ios::binary);
 
     if (!infile)
     {
         std::ostringstream s;
 
-        s << "could not open file " << file;
+        s << "could not open file " << fname;
         throw std::runtime_error(s.str());
     }
     infile.seekg(0, std::ios::end);

--- a/shader.h
+++ b/shader.h
@@ -1,9 +1,9 @@
 /* shader.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 13 Mar 2016, 10:34:49 tquirk
+ *   last updated 11 Oct 2017, 15:57:23 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2016  Trinity Annabelle Quirk
+ * Copyright (C) 2017  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -33,6 +33,7 @@
 
 #include <GL/gl.h>
 
+std::string shader_path(void);
 GLuint load_shader(GLenum, const std::string&);
 GLuint create_shader(GLenum, const std::string&);
 GLuint create_program(GLuint, GLuint, GLuint, const char *);

--- a/ui.cc
+++ b/ui.cc
@@ -1,6 +1,6 @@
 /* ui.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 31 Aug 2017, 22:24:26 tquirk
+ *   last updated 11 Oct 2017, 15:55:44 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -71,10 +71,8 @@ ui::context::context(GLuint w, GLuint h)
     : ui::composite::composite(NULL, w, h), ui::active::active(w, h),
       ui::rect::rect(w, h)
 {
-    this->vert_shader = load_shader(GL_VERTEX_SHADER,
-                                    SHADER_SRC_PATH "/ui_vertex.glsl");
-    this->frag_shader = load_shader(GL_FRAGMENT_SHADER,
-                                    SHADER_SRC_PATH "/ui_fragment.glsl");
+    this->vert_shader = load_shader(GL_VERTEX_SHADER, "ui_vertex.glsl");
+    this->frag_shader = load_shader(GL_FRAGMENT_SHADER, "ui_fragment.glsl");
     this->shader_pgm = create_program(vert_shader, 0, frag_shader, "fcolor");
     glUseProgram(this->shader_pgm);
     this->pos_attr = glGetAttribLocation(shader_pgm, "position");


### PR DESCRIPTION
We set a default shader path at configure time, which is compiled
into the library.  We can now override it with the
CUDDLY_SHADER_PATH environment variable.

Re:  issue #20