### PR TITLE
Repair pie menu

### DIFF
--- a/manager.cc
+++ b/manager.cc
@@ -1,6 +1,6 @@
 /* manager.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 05 Oct 2017, 08:35:35 tquirk
+ *   last updated 30 Oct 2017, 08:20:48 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -142,6 +142,7 @@ void ui::manager::set_desired_size(void)
         if (max_pt.y > this->dim.y)
             this->dim.y = max_pt.y;
     }
+    this->dirty = false;
     this->regenerate_search_tree();
     this->populate_buffers();
 }

--- a/pie_menu.cc
+++ b/pie_menu.cc
@@ -1,6 +1,6 @@
 /* pie_menu.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 31 Aug 2017, 22:15:01 tquirk
+ *   last updated 24 Oct 2017, 08:07:58 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -179,15 +179,14 @@ ui::vertex_buffer *ui::pie_menu::generate_points(void)
 ui::pie_menu::pie_menu(composite *c, GLuint w, GLuint h)
     : ui::manager::manager(c, w, h), ui::active::active(w, h), ui::rect(w, h)
 {
-    ui::active *a = dynamic_cast<ui::active *>(c);
     this->popup_button = ui::mouse::button2;
     this->resize = ui::resize::none;
     this->visible = false;
 
-    if (a != NULL)
+    if (c != NULL)
     {
-        a->add_callback(ui::callback::btn_down, ui::pie_menu::show, this);
-        a->add_callback(ui::callback::btn_up, ui::pie_menu::hide, this);
+        c->add_callback(ui::callback::btn_down, ui::pie_menu::show, this);
+        c->add_callback(ui::callback::btn_up, ui::pie_menu::hide, this);
     }
     this->add_callback(ui::callback::btn_up, ui::pie_menu::hide, this);
 
@@ -196,12 +195,14 @@ ui::pie_menu::pie_menu(composite *c, GLuint w, GLuint h)
 
 ui::pie_menu::~pie_menu()
 {
-    ui::active *a;
-
-    if ((a = dynamic_cast<ui::active *>(this->composite::parent)) != NULL)
+    if (this->composite::parent != NULL)
     {
-        a->remove_callback(ui::callback::btn_down, ui::pie_menu::show, this);
-        a->remove_callback(ui::callback::btn_up, ui::pie_menu::hide, this);
+        this->composite::parent->remove_callback(ui::callback::btn_down,
+                                                 ui::pie_menu::show,
+                                                 this);
+        this->composite::parent->remove_callback(ui::callback::btn_up,
+                                                 ui::pie_menu::hide,
+                                                 this);
     }
 }
 

--- a/pie_menu.cc
+++ b/pie_menu.cc
@@ -1,6 +1,6 @@
 /* pie_menu.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 30 Oct 2017, 09:19:49 tquirk
+ *   last updated 30 Oct 2017, 09:22:46 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -106,7 +106,7 @@ void ui::pie_menu::set_desired_size(void)
 
     if (this->children.size() > 0)
     {
-        int increment;
+        float increment;
         auto child = this->children.begin();
         glm::ivec2 child_pos, child_size;
         glm::ivec2 middle = this->dim / 4;
@@ -122,9 +122,9 @@ void ui::pie_menu::set_desired_size(void)
              */
             (*child)->get(ui::element::size, ui::size::all, &child_size);
             child_pos.x = (int)truncf((float)middle.x * cos(angle))
-                + this->pos.x - (child_size.x / 2);
+                - (child_size.x / 2);
             child_pos.y = (int)truncf((float)middle.y * sin(angle))
-                + this->pos.y - (child_size.y / 2);
+                - (child_size.y / 2);
             (*child)->set(ui::element::position, ui::position::all, &child_pos);
         }
     }
@@ -178,7 +178,7 @@ ui::vertex_buffer *ui::pie_menu::generate_points(void)
 
     if (this->children.size() > 0)
     {
-        int increment = M_PI * 2.0f / this->children.size();
+        float increment = M_PI * 2.0f / this->children.size();
 
         for (int i = 0; i < this->children.size(); ++i)
         {

--- a/pie_menu.cc
+++ b/pie_menu.cc
@@ -1,6 +1,6 @@
 /* pie_menu.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 30 Oct 2017, 09:22:46 tquirk
+ *   last updated 30 Oct 2017, 09:28:25 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -129,6 +129,7 @@ void ui::pie_menu::set_desired_size(void)
         }
     }
     this->dirty = false;
+    this->populate_buffers();
 }
 
 ui::vertex_buffer *ui::pie_menu::generate_points(void)

--- a/pie_menu.cc
+++ b/pie_menu.cc
@@ -1,6 +1,6 @@
 /* pie_menu.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 26 Oct 2017, 09:43:16 tquirk
+ *   last updated 30 Oct 2017, 09:19:49 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -128,6 +128,7 @@ void ui::pie_menu::set_desired_size(void)
             (*child)->set(ui::element::position, ui::position::all, &child_pos);
         }
     }
+    this->dirty = false;
 }
 
 ui::vertex_buffer *ui::pie_menu::generate_points(void)

--- a/pie_menu.cc
+++ b/pie_menu.cc
@@ -1,6 +1,6 @@
 /* pie_menu.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 24 Oct 2017, 08:07:58 tquirk
+ *   last updated 26 Oct 2017, 09:43:16 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -100,6 +100,36 @@ void ui::pie_menu::hide(ui::active *a, void *call, void *client)
     }
 }
 
+void ui::pie_menu::set_desired_size(void)
+{
+    this->composite::set_desired_size();
+
+    if (this->children.size() > 0)
+    {
+        int increment;
+        auto child = this->children.begin();
+        glm::ivec2 child_pos, child_size;
+        glm::ivec2 middle = this->dim / 4;
+
+        increment = M_PI * 2.0f / this->children.size();
+
+        for (int i = 0; i < this->children.size(); ++i, ++child)
+        {
+            float angle = increment * (i + 0.5);
+
+            /* Reposition each child to be in the middle of its
+             * sector.
+             */
+            (*child)->get(ui::element::size, ui::size::all, &child_size);
+            child_pos.x = (int)truncf((float)middle.x * cos(angle))
+                + this->pos.x - (child_size.x / 2);
+            child_pos.y = (int)truncf((float)middle.y * sin(angle))
+                + this->pos.y - (child_size.y / 2);
+            (*child)->set(ui::element::position, ui::position::all, &child_pos);
+        }
+    }
+}
+
 ui::vertex_buffer *ui::pie_menu::generate_points(void)
 {
     glm::vec2 pixel_sz;
@@ -147,29 +177,15 @@ ui::vertex_buffer *ui::pie_menu::generate_points(void)
 
     if (this->children.size() > 0)
     {
-        auto child = this->children.begin();
-        glm::ivec2 middle = this->dim / 4;
-        glm::ivec2 child_pos, child_size;
         int increment = M_PI * 2.0f / this->children.size();
 
-        for (int i = 0; i < this->children.size(); ++i, ++child)
+        for (int i = 0; i < this->children.size(); ++i)
         {
             float angle = increment * i;
 
             pct = m3.x / m0.x;
             vb->generate_ellipse_divider(center, m0, pct, angle,
                                          this->foreground);
-
-            /* Reposition each child to be in the middle of its
-             * sector.
-             */
-            angle += increment / 2.0f;
-            (*child)->get(ui::element::size, ui::size::all, &child_size);
-            child_pos.x = (int)truncf((float)middle.x * cos(angle))
-                + this->pos.x - (child_size.x / 2);
-            child_pos.y = (int)truncf((float)middle.y * sin(angle))
-                + this->pos.y - (child_size.y / 2);
-            (*child)->set(ui::element::position, ui::position::all, &child_pos);
         }
     }
 

--- a/pie_menu.h
+++ b/pie_menu.h
@@ -1,6 +1,6 @@
 /* pie_menu.h                                              -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 26 Feb 2017, 09:25:12 tquirk
+ *   last updated 26 Oct 2017, 08:48:08 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2016  Trinity Annabelle Quirk
@@ -46,6 +46,8 @@ namespace ui
 
         static void show(active *, void *, void *);
         static void hide(active *, void *, void *);
+
+        virtual void set_desired_size(void) override;
 
         virtual vertex_buffer *generate_points(void) override;
 

--- a/test/run-uitest
+++ b/test/run-uitest
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More 'tests' => 7;
+use Test::More 'tests' => 12;
 
 use X11::GUITest qw(:ALL :CONST);
 
@@ -29,8 +29,17 @@ sub interact_with_button
 {
     my $test = 'button';
 
-    my $status = ClickWindow($uitest, 60, 185, M_BTN1);
-    ok($status, "$test: clicked button 1");
+    my ($x, $y) = GetWindowPos($uitest);
+    ok(defined $x, "$test: x pos is defined");
+    ok(defined $y, "$test: y pos is defined");
+    my $status = MoveMouseAbs($x + 60, $y + 185);
+    ok($status, "$test: moved mouse to right spot");
+    $status = PressMouseButton(M_BTN1);
+    ok($status, "$test: pressed button 1");
+    $status = MoveMouseAbs($x + 100, $y + 185);
+    ok($status, "$test: moved mouse again");
+    $status = ReleaseMouseButton(M_BTN1);
+    ok($status, "$test: released button 1");
 }
 
 sub interact_with_row_column


### PR DESCRIPTION
The pie menu children weren't being positioned properly, and the sector boundaries weren't being drawn.  There were some other things that got missed in some earlier conversions, which are included here.