### PR TITLE
Ensure libtap++ is only built during a test

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -10,7 +10,7 @@ TC += uitest
 TS += run-uitest
 endif
 
-SUBDIRS = tap++
+SUBDIRS = tap++ .
 
 TEST_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
 	$(top_srcdir)/build-aux/tap-driver.sh

--- a/test/tap++/Makefile.am
+++ b/test/tap++/Makefile.am
@@ -1,4 +1,4 @@
-lib_LTLIBRARIES = libtap++.la
+check_LTLIBRARIES = libtap++.la
 
 libtap___la_SOURCES = tap++.C tap++.h
 libtap___la_CXXFLAGS = -I..


### PR DESCRIPTION
We only need libtap++ during the test suite, and not during the
regular build.  Set the tap++ directory to build before the test
directory, and make sure the library is a check target.

Re:  issue #38