### PR TITLE
Allow disabling of the GUI tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,8 @@ AC_ARG_ENABLE([profile],
               AS_HELP_STRING([--enable-profile], [Build binaries with profiling support]),
               [],
               [enable_profile="no"])
+AC_ARG_ENABLE([gui-tests],
+              AS_HELP_STRING([--disable-gui-tests], [Don't perform tests with X11 driver]))
 
 AC_ARG_WITH([freetype],
             AS_HELP_STRING([--with-freetype=<path>], [Freetype2 install root]),
@@ -155,7 +157,7 @@ AS_IF([test "x$with_glfw" != "xno"],
         CPPFLAGS="$CXXFLAGS"
         AC_CHECK_HEADERS([GLFW/glfw3.h],
                          [can_do_tests="yes"],
-                         [AC_MSG_NOTICE([no GLFW headers found, not building test suite])])
+                         [AC_MSG_NOTICE([no GLFW headers found, not building GUI test suite])])
 
         AS_IF([test "x$can_do_tests" == "xyes"],
               [
@@ -167,18 +169,24 @@ AS_IF([test "x$with_glfw" != "xno"],
                 AC_SEARCH_LIBS([glfwInit], [glfw],
                                [GLFW_LDLIBS="$ac_cv_search_glfwInit"],
                                [
-                                 AC_MSG_NOTICE([no GLFW libraries found, not building test suite])
+                                 AC_MSG_NOTICE([no GLFW libraries found, not building GUI test suite])
                                  can_do_tests="no"
                                ])])
         AX_RESTORE_FLAGS_WITH_PREFIX([GLFW],
                                      [[CPPFLAGS],[CXXFLAGS],[LDFLAGS],[LIBS]])
-        AX_PROG_PERL_MODULES([Test::More X11::GUITest],
-                             [],
-                             [AC_MSG_NOTICE([X11::GUITest is installed enough for our purposes])],
-                             [
-                               AC_MSG_NOTICE([missing perl modules, not building test suite])
-                               can_do_tests="no"
-                             ])
+        AS_IF([test "x$enable_gui_tests" != "xno"],
+              [AX_PROG_PERL_MODULES([Test::More X11::GUITest],
+                                    [],
+                                    [AC_MSG_NOTICE([X11::GUITest is installed enough for our purposes])],
+                                    [
+                                      AC_MSG_NOTICE([missing perl modules, not building GUI test suite])
+                                      can_do_tests="no"
+                                    ])
+              ],
+              [
+                AC_MSG_NOTICE([not building GUI test suite due to option])
+                can_do_tests="no"
+              ])
       ])
 AM_CONDITIONAL([HAVE_TEST_PREREQS], [test "x$can_do_tests" == "xyes"])
 AS_IF([test "x$can_do_tests" == "xyes"],


### PR DESCRIPTION
The configure validates the usability of various perl modules,
including X11::GUITest.  On OSX, that starts up the XQuartz system,
which can take some time.  This change adds the --disable-gui-tests
configure flag, to disable such checking, and the running of the
GUI tests.  The uitest program can still be built by hand, if
desired.