### PR TITLE
Repair segfaults in rule W2

### DIFF
--- a/bidi.cc
+++ b/bidi.cc
@@ -1,6 +1,6 @@
 /* bidi.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 20 May 2018, 17:29:44 tquirk
+ *   last updated 23 May 2018, 21:16:47 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -459,7 +459,7 @@ void bidi::rule_w2(bidi::run_sequence& seq)
     do
         if (i->c_class == class_EN)
         {
-            auto j = i - 1;
+            auto j = i;
             do
             {
                 if (j->c_class == class_R
@@ -470,8 +470,12 @@ void bidi::rule_w2(bidi::run_sequence& seq)
                         i->c_class = class_AN;
                     break;
                 }
-                if (j == seq.start && seq.sos == class_AL)
-                    i->c_class = class_AN;
+                if (j == seq.start)
+                {
+                    if (seq.sos == class_AL)
+                        i->c_class = class_AN;
+                    break;
+                }
             }
             while (j-- != seq.start);
         }

--- a/test/t_bidi.cc
+++ b/test/t_bidi.cc
@@ -1277,6 +1277,21 @@ void test_rule_w2(void)
     b.rule_w2(seq2);
 
     is(cc2.back().c_class, class_AN, test + st + "expected type");
+
+    st = "all EN: ";
+
+    fake_bidi::char_container cc3 =
+    {
+        {'4', class_EN, 1}, {'5', class_EN, 1}
+    };
+    fake_bidi::run_sequence seq3 =
+    {
+        cc3.begin(), cc3.end() - 1, class_L, class_L
+    };
+
+    b.rule_w2(seq3);
+
+    is(cc3.back().c_class, class_EN, test + st + "expected type");
 }
 
 void test_rule_w3(void)
@@ -1932,7 +1947,7 @@ void test_reorder(void)
 
 int main(int argc, char **argv)
 {
-    plan(354);
+    plan(355);
 
     test_create_delete();
     test_char_type();


### PR DESCRIPTION
We're seeing some segfaults in rule W2, where there is a character
of class EN in the first position.  We need to break out of the
inner loop when we're at the start.  We also need to consider that
our EN might be at the start of the run sequence.