### PR TITLE
Repair segfaults in rule W7

### DIFF
--- a/bidi.cc
+++ b/bidi.cc
@@ -1,6 +1,6 @@
 /* bidi.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 23 May 2018, 21:16:47 tquirk
+ *   last updated 23 May 2018, 23:30:14 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -564,7 +564,7 @@ void bidi::rule_w7(bidi::run_sequence& seq)
     do
         if (i->c_class == class_EN)
         {
-            auto j = i - 1;
+            auto j = i;
             do
             {
                 if (j->c_class == class_R
@@ -575,8 +575,12 @@ void bidi::rule_w7(bidi::run_sequence& seq)
                         i->c_class = class_L;
                     break;
                 }
-                if (j == seq.start && seq.sos == class_L)
-                    i->c_class = class_L;
+                if (j == seq.start)
+                {
+                    if (seq.sos == class_L)
+                        i->c_class = class_L;
+                    break;
+                }
             }
             while (j-- != seq.start);
         }

--- a/test/t_bidi.cc
+++ b/test/t_bidi.cc
@@ -1485,6 +1485,21 @@ void test_rule_w7(void)
     b.rule_w7(seq2);
 
     is(cc2.back().c_class, class_L, test + st + "expected type");
+
+    st = "all EN: ";
+
+    fake_bidi::char_container cc3 =
+    {
+        {'4', class_EN, 1}, {'5', class_EN, 1}
+    };
+    fake_bidi::run_sequence seq3 =
+    {
+        cc3.begin(), cc3.end() - 1, class_R, class_R
+    };
+
+    b.rule_w7(seq3);
+
+    is(cc3.back().c_class, class_EN, test + st + "expected type");
 }
 
 void test_bd16(void)
@@ -1947,7 +1962,7 @@ void test_reorder(void)
 
 int main(int argc, char **argv)
 {
-    plan(355);
+    plan(356);
 
     test_create_delete();
     test_char_type();


### PR DESCRIPTION
Similarly with the segfaults we were seeing in rule W2, rule W7
was having troubles if the first character in the sequence was of
class EN.