### PR TITLE
Allow disabling of the GUI tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,8 @@ AC_ARG_ENABLE([profile],
               AS_HELP_STRING([--enable-profile], [Build binaries with profiling support]),
               [],
               [enable_profile="no"])
+AC_ARG_ENABLE([gui-tests],
+              AS_HELP_STRING([--disable-gui-tests], [Don't perform tests with X11 driver]))
 
 AC_ARG_WITH([freetype],
             AS_HELP_STRING([--with-freetype=<path>], [Freetype2 install root]),
@@ -171,7 +173,7 @@ AS_IF([test "x$with_glfw" != "xno"],
         CPPFLAGS="$CXXFLAGS"
         AC_CHECK_HEADERS([GLFW/glfw3.h],
                          [can_do_tests="yes"],
-                         [AC_MSG_NOTICE([no GLFW headers found, not building test suite])])
+                         [AC_MSG_NOTICE([no GLFW headers found, not building GUI test suite])])
 
         AS_IF([test "x$can_do_tests" == "xyes"],
               [
@@ -183,20 +185,27 @@ AS_IF([test "x$with_glfw" != "xno"],
                 AC_SEARCH_LIBS([glfwInit], [glfw],
                                [GLFW_LDLIBS="$ac_cv_search_glfwInit"],
                                [
-                                 AC_MSG_NOTICE([no GLFW libraries found, not building test suite])
+                                 AC_MSG_NOTICE([no GLFW libraries found, not building GUI test suite])
                                  can_do_tests="no"
                                ])])
         AX_RESTORE_FLAGS_WITH_PREFIX([GLFW],
                                      [[CPPFLAGS],[CXXFLAGS],[LDFLAGS],[LIBS]])
-        AX_PROG_PERL_MODULES([Test::More X11::GUITest],
-                             [],
-                             [AC_MSG_NOTICE([X11::GUITest is installed enough for our purposes])],
-                             [
-                               AC_MSG_NOTICE([missing perl modules, not building test suite])
-                               can_do_tests="no"
-                             ])
+        AS_IF([test "x$enable_gui_tests" != "xno"],
+              [AX_PROG_PERL_MODULES([Test::More X11::GUITest],
+                                    [AC_MSG_NOTICE([enabling GUI test suite])],
+                                    [AC_MSG_NOTICE([X11::GUITest is installed enough for our purposes])],
+                                    [
+                                      AC_MSG_NOTICE([missing perl modules, disabling GUI test suite])
+                                      enable_gui_tests="no"
+                                    ])
+              ],
+              [AS_IF([test "x$can_do_tests" == "xyes"],
+                     [AC_MSG_NOTICE([disabling GUI test suite by option])])
+              ]
+        )
       ])
 AM_CONDITIONAL([HAVE_TEST_PREREQS], [test "x$can_do_tests" == "xyes"])
+AM_CONDITIONAL([WANT_GUI_TESTS], [test "x$enable_gui_tests" != "xno"])
 AS_IF([test "x$can_do_tests" == "xyes"],
       [AS_CASE([$host_os],
                [darwin*],

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -9,7 +9,9 @@ TS = fonttest \
 
 if HAVE_TEST_PREREQS
 TC += uitest
+if WANT_GUI_TESTS
 TS += run-uitest
+endif
 endif
 
 SUBDIRS = tap++ .


### PR DESCRIPTION
The configure validates the usability of various perl modules,
including X11::GUITest.  On OSX, that starts up the XQuartz system,
which can take some time, and doesn't work properly anyway.  This
change adds the --disable-gui-tests configure flag to disable such
checking, and the running of the GUI tests.  If the GLFW prereqs
are found, we'll still build the program, but we won't run it
during 'make check'.

Previous attempts at this change made the uitest program not work
properly, but we've verified that everything still looks fine with
the --disable-gui-tests flag set.