### PR TITLE
Overload set methods

### DIFF
--- a/button.cc
+++ b/button.cc
@@ -1,6 +1,6 @@
 /* button.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 10 Aug 2018, 22:39:42 tquirk
+ *   last updated 02 Sep 2018, 08:28:02 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -47,43 +47,40 @@ int ui::button::get_state(GLuint t, void *v) const
     }
 }
 
-void ui::button::set_state(GLuint t, const void *v)
+void ui::button::set_state(GLuint t, bool v)
 {
-    bool val = *reinterpret_cast<const bool *>(v);
-
     switch (t)
     {
-      case ui::state::active:  this->set_active_state(val);   break;
-      case ui::state::armed:   this->set_arm_state(val);      break;
+      case ui::state::active:  this->set_active_state(v);     break;
+      case ui::state::armed:   this->set_arm_state(v);        break;
       default:                 this->label::set_state(t, v);  break;
     }
 }
 
-void ui::button::set_margin(GLuint s, const void *v)
+void ui::button::set_margin(GLuint s, GLuint v)
 {
-    GLuint new_v = *reinterpret_cast<const GLuint *>(v);
     GLuint min_val = (this->activated ? 0 : 1) + (this->armed ? 0 : 1);
 
     if (s & ui::side::top || s & ui::side::bottom)
         if (this->border[0] + this->border[3]
-            + ((s & ui::side::top) ? new_v : this->margin[0])
-            + ((s & ui::side::bottom) ? new_v : this->margin[3]) <= this->dim.y)
+            + ((s & ui::side::top) ? v : this->margin[0])
+            + ((s & ui::side::bottom) ? v : this->margin[3]) <= this->dim.y)
         {
             if (s & ui::side::top)
-                this->margin[0] = std::max(new_v, min_val);
+                this->margin[0] = std::max(v, min_val);
             if (s & ui::side::bottom)
-                this->margin[3] = std::max(new_v, min_val);
+                this->margin[3] = std::max(v, min_val);
         }
 
     if (s & ui::side::left || s & ui::side::right)
         if (this->border[1] + this->border[2]
-            + ((s & ui::side::left) ? new_v : this->margin[1])
-            + ((s & ui::side::right) ? new_v : this->margin[2]) <= this->dim.x)
+            + ((s & ui::side::left) ? v : this->margin[1])
+            + ((s & ui::side::right) ? v : this->margin[2]) <= this->dim.x)
         {
             if (s & ui::side::left)
-                this->margin[1] = std::max(new_v, min_val);
+                this->margin[1] = std::max(v, min_val);
             if (s & ui::side::right)
-                this->margin[2] = std::max(new_v, min_val);
+                this->margin[2] = std::max(v, min_val);
         }
     this->populate_buffers();
 }
@@ -144,39 +141,35 @@ void ui::button::shrink_border(void)
 void ui::button::activate(ui::active *a, void *call, void *client)
 {
     ui::button *b = dynamic_cast<ui::button *>(a);
-    bool active = true;
 
     if (b != NULL)
-        b->set(ui::element::state, ui::state::active, &active);
+        b->set(ui::element::state, ui::state::active, true);
 }
 
 /* ARGSUSED */
 void ui::button::deactivate(ui::active *a, void *call, void *client)
 {
     ui::button *b = dynamic_cast<ui::button *>(a);
-    bool active = false;
 
     if (b != NULL)
-        b->set(ui::element::state, ui::state::active, &active,
-               ui::element::state, ui::state::armed, &active);
+        b->set(ui::element::state, ui::state::active, false,
+               ui::element::state, ui::state::armed, false);
 }
 
 void ui::button::arm(ui::active *a, void *call, void *client)
 {
     ui::button *b = dynamic_cast<ui::button *>(a);
-    bool armed = true;
 
     if (b != NULL)
-        b->set(ui::element::state, ui::state::armed, &armed);
+        b->set(ui::element::state, ui::state::armed, true);
 }
 
 void ui::button::disarm(ui::active *a, void *call, void *client)
 {
     ui::button *b = dynamic_cast<ui::button *>(a);
-    bool armed = false;
 
     if (b != NULL)
-        b->set(ui::element::state, ui::state::armed, &armed);
+        b->set(ui::element::state, ui::state::armed, false);
 }
 
 ui::button::button(ui::composite *c, GLuint w, GLuint h)

--- a/button.cc
+++ b/button.cc
@@ -1,6 +1,6 @@
 /* button.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 05 Aug 2018, 08:06:24 tquirk
+ *   last updated 10 Aug 2018, 22:39:42 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -157,8 +157,8 @@ void ui::button::deactivate(ui::active *a, void *call, void *client)
     bool active = false;
 
     if (b != NULL)
-        b->set_va(ui::element::state, ui::state::active, &active,
-                  ui::element::state, ui::state::armed, &active, 0);
+        b->set(ui::element::state, ui::state::active, &active,
+               ui::element::state, ui::state::armed, &active);
 }
 
 void ui::button::arm(ui::active *a, void *call, void *client)

--- a/button.h
+++ b/button.h
@@ -1,6 +1,6 @@
 /* button.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 28 Jul 2018, 07:51:51 tquirk
+ *   last updated 02 Sep 2018, 08:26:33 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -43,8 +43,8 @@ namespace ui
         bool activated, armed;
 
         virtual int get_state(GLuint, void *) const override;
-        virtual void set_state(GLuint, const void *) override;
-        virtual void set_margin(GLuint, const void *) override;
+        virtual void set_state(GLuint, bool) override;
+        virtual void set_margin(GLuint, GLuint) override;
 
         int get_active_state(bool *) const;
         void set_active_state(bool);

--- a/composite.cc
+++ b/composite.cc
@@ -1,6 +1,6 @@
 /* composite.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Jul 2018, 09:22:26 tquirk
+ *   last updated 08 Sep 2018, 07:51:13 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -36,7 +36,7 @@
 
 const int ui::composite::tree_max_depth = 4;
 
-void ui::composite::set_size(GLuint d, const void *v)
+void ui::composite::set_size(GLuint d, GLuint v)
 {
     ui::resize_call_data call_data;
 
@@ -48,18 +48,28 @@ void ui::composite::set_size(GLuint d, const void *v)
         (*i)->call_callbacks(ui::callback::resize, &call_data);
 }
 
+void ui::composite::set_size(GLuint d, const glm::ivec2& v)
+{
+    ui::resize_call_data call_data;
+
+    this->rect::set_size(d, v);
+    this->regenerate_children();
+    this->regenerate_search_tree();
+    call_data.new_size = this->dim;
+    for (auto i : this->children)
+        i->call_callbacks(ui::callback::resize, &call_data);
+}
+
 int ui::composite::get_resize(GLuint t, void *v) const
 {
     *reinterpret_cast<GLuint *>(v) = this->resize;
     return 0;
 }
 
-void ui::composite::set_resize(GLuint t, const void *v)
+void ui::composite::set_resize(GLuint t, GLuint v)
 {
-    GLuint new_v = *reinterpret_cast<const GLuint *>(v);
-
-    if (new_v <= ui::resize::all)
-        this->resize = new_v;
+    if (v <= ui::resize::all)
+        this->resize = v;
 }
 
 int ui::composite::get_pixel_size(GLuint t, void *v) const
@@ -186,13 +196,12 @@ int ui::composite::get(GLuint e, GLuint t, void *v) const
     }
 }
 
-void ui::composite::set(GLuint e, GLuint t, const void *v)
+void ui::composite::set(GLuint e, GLuint t, GLuint v)
 {
     switch (e)
     {
       case ui::element::size:    this->set_size(t, v);    break;
       case ui::element::resize:  this->set_resize(t, v);  break;
-      default:                   return;
     }
 }
 

--- a/composite.h
+++ b/composite.h
@@ -1,6 +1,6 @@
 /* composite.h                                             -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 12 Aug 2018, 07:04:14 tquirk
+ *   last updated 02 Sep 2018, 09:03:26 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -56,9 +56,10 @@ namespace ui
 
         const static int tree_max_depth;
 
-        virtual void set_size(GLuint, const void *) override;
+        virtual void set_size(GLuint, GLuint) override;
+        virtual void set_size(GLuint, const glm::ivec2&) override;
         virtual int get_resize(GLuint, void *) const;
-        virtual void set_resize(GLuint, const void *);
+        virtual void set_resize(GLuint, GLuint);
         virtual int get_pixel_size(GLuint, void *) const;
 
         virtual void set_desired_size(void);
@@ -76,7 +77,8 @@ namespace ui
         virtual ~composite();
 
         virtual int get(GLuint, GLuint, void *) const override;
-        virtual void set(GLuint, GLuint, const void *) override;
+        using ui::rect::set;
+        virtual void set(GLuint, GLuint, GLuint) override;
 
         GET_VA;
         SET_VA;

--- a/composite.h
+++ b/composite.h
@@ -1,6 +1,6 @@
 /* composite.h                                             -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 28 Jul 2018, 07:41:16 tquirk
+ *   last updated 12 Aug 2018, 07:04:14 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -77,6 +77,9 @@ namespace ui
 
         virtual int get(GLuint, GLuint, void *) const override;
         virtual void set(GLuint, GLuint, const void *) override;
+
+        GET_VA;
+        SET_VA;
 
         virtual void add_child(widget *);
         virtual void remove_child(widget *);

--- a/doc/ui.md
+++ b/doc/ui.md
@@ -77,22 +77,22 @@ b->get(ui::element::string, 0, &some_string);
 /* some_string is now "Howdy!" */
 ```
 
-There are also vararg-type get and set functions for each object,
-`get_va` and `set_va`.  Syntax is mostly the same, sets of
-element/type/value, and ends with an extra 0.
+The get and set functions can also be used in a variable-length
+argument context.  Syntax is mostly the same, with sets of
+element/type/value.
 
 Examples:
 
 ```c++
 ui::widget *p = new ui::widget(parent, 100, 100);
 int margin = 5, border = 1;
-p->set_va(ui::element::margin, ui::side::all, &margin,
-          ui::element::border, ui::side::top, &border, 0);
+p->set(ui::element::margin, ui::side::all, &margin,
+       ui::element::border, ui::side::top, &border);
 
 margin = 123;
 border = 456;
-p->get_va(ui::element::margin, ui::side::right, &margin,
-          ui::element::border, ui::side::bottom, &border, 0);
+p->get(ui::element::margin, ui::side::right, &margin,
+       ui::element::border, ui::side::bottom, &border);
 /* margin is now 5, and border is now 1 */
 ```
 

--- a/doc/ui::active.md
+++ b/doc/ui::active.md
@@ -292,17 +292,15 @@ mappings to the underlying types, but with shorter names.
   to fire the timeout call, but in the general case, this method would
   probably not be used very often in user code.
 
-* **get(type, subtype, obj_ptr) const**
-* **set(type, subtype, obj_ptr)**
-* **get_va(type, subtype, obj_ptr, ...) const**
-* **set_va(type, subtype, obj_ptr, ...)**
+* **get(type, subtype, obj_ptr, ...) const**
+* **set(type, subtype, obj_ptr, ...)**
 
   Inherited from [`ui::rect`](ui::rect).
 
 ## NEW RESOURCES ##
 
 The `ui::active` adds no new resources which are accessed via the
-`get()/set()` and `get_va()/set_va()` methods.
+`get()/set()` methods.
 
 ## INHERITED RESOURCES ##
 

--- a/doc/ui::rect.md
+++ b/doc/ui::rect.md
@@ -13,20 +13,19 @@ ui::rect
 ui::rect *r = new ui::rect(x, y);
 
 r->set(ui::element::size, ui::size::width, &different_x);
-r->set_va(ui::element::size, ui::size::width, &other_x,
-          ui::element::size, ui::size::height, &other_y, 0);
+r->set(ui::element::size, ui::size::width, &other_x,
+       ui::element::size, ui::size::height, &other_y);
 
 r->get(ui::element::size, ui::size::all, &xy_vector);
-r->get_va(ui::element::size, ui::size::width, &x_target,
-          ui::element::size, ui::size::height, &y_target, 0);
+r->get(ui::element::size, ui::size::width, &x_target,
+       ui::element::size, ui::size::height, &y_target);
 ```
 
 ## DESCRIPTION ##
 
 The `ui::rect` class is the base of all widgets in the CuddlyGL widget
-set.  It has a width and a height.  It also contains the base `get()`
-and `set()` methods, along with the variable-argument `get_va()` and
-`set_va()` methods.
+set.  It has a width and a height.  It also contains the `get()` and
+`set()` methods, which function in a variable-argument context.
 
 The `ui::rect` has no methods or facilities which interact with
 OpenGL, and can not be drawn on the screen in any way; it is strictly
@@ -34,35 +33,26 @@ a base class with a size.
 
 ## METHODS ##
 
-* **get(type, subtype, obj_ptr) const**
+* **get(type, subtype, obj_ptr, ...) const**
 
-  Retrieve resources from the object.  The `type` argument will be
-  from the `ui::element` namespace, and the `subtype` argument will be
-  from a namespace which corresponds to the primary type.  The
-  `obj_ptr` argument is a `void *`.
+  Retrieve resources from the object.  Arguments are given in sets of
+  three.  The `type` argument will be from the `ui::element`
+  namespace, and the `subtype` argument will be from a namespace which
+  corresponds to the primary type.  The `obj_ptr` argument is a
+  `void *`.  The function can take any number of sets of these three
+  arguments.
 
-* **set(type, subtype, obj_ptr)**
+* **set(type, subtype, obj_ptr, ...)**
 
-  Set resources within the object.  As with the `get()` method, the
-  `type` argument is an item from the `ui::element` namespace, and the
-  `subtype` is from the corresponding sub-namespace.  The `obj_ptr` is
-  a `const void *`.
+  Set resources within the object.  As with the `get()` method,
+  arguments are provided in sets of three, with the `type` argument
+  being an item from the `ui::element` namespace, the `subtype` from
+  the corresponding sub-namespace, and the `obj_ptr` a `const void *`.
+  This function can also take any number of three-argument sets.
 
-* **get_va(type, subtype, obj_ptr, ...) const**
-
-  A variable-argument version of the `get()` method.  Argument list is
-  sets of the three regular `get()` arguments, terminated with an
-  additional 0.
-
-* **set_va(type, subtype, obj_ptr, ...)**
-
-  A variable-argument version of the `set()` method.  Argument list is
-  sets of the three regular `set()` arguments, terminated with an
-  additional 0.
-
-The variable-argument methods should not need to be overridden by any
-subclasses; they call out to the corresponding `get()`/`set()`
-methods.
+The variable-argument methods need to be added to each subclass which
+overrides either the get() or set() method.  They are added by
+preprocessor macros within `ui_defs.h`:  `GET_VA` and `SET_VA`.
 
 ## NEW RESOURCES ##
 

--- a/label.cc
+++ b/label.cc
@@ -1,6 +1,6 @@
 /* label.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 04 Aug 2018, 15:35:08 tquirk
+ *   last updated 04 Sep 2018, 06:48:26 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -46,13 +46,13 @@ int ui::label::get_font(GLuint t, void *v) const
 }
 
 /* ARGSUSED */
-void ui::label::set_font(GLuint t, const void *v)
+void ui::label::set_font(GLuint t, const ui::base_font *v)
 {
     if (t == ui::ownership::shared)
         this->shared_font = true;
     else
         this->shared_font = false;
-    this->font = (ui::base_font *)v;
+    this->font = const_cast<ui::base_font *>(v);
     this->generate_string_image();
 }
 
@@ -64,9 +64,9 @@ int ui::label::get_string(GLuint t, void *v) const
 }
 
 /* ARGSUSED */
-void ui::label::set_string(GLuint t, const void *v)
+void ui::label::set_string(GLuint t, const std::string& v)
 {
-    this->str = ui::utf8tou32str(*reinterpret_cast<const std::string *>(v));
+    this->str = ui::utf8tou32str(v);
     this->generate_string_image();
 }
 
@@ -78,20 +78,20 @@ int ui::label::get_image(GLuint t, void *v) const
 }
 
 /* ARGSUSED */
-void ui::label::set_image(GLuint t, const void *v)
+void ui::label::set_image(GLuint t, const ui::image& v)
 {
     this->str.clear();
-    this->img = *reinterpret_cast<const ui::image *>(v);
+    this->img = v;
     this->calculate_widget_size();
 }
 
-void ui::label::set_border(GLuint t, const void *v)
+void ui::label::set_border(GLuint t, GLuint v)
 {
     this->widget::set_border(t, v);
     this->calculate_widget_size();
 }
 
-void ui::label::set_margin(GLuint t, const void *v)
+void ui::label::set_margin(GLuint t, GLuint v)
 {
     this->widget::set_margin(t, v);
     this->calculate_widget_size();
@@ -126,7 +126,7 @@ void ui::label::calculate_widget_size(void)
         size.y = this->img.height
             + this->margin[0] + this->margin[3]
             + this->border[0] + this->border[3] + 2;
-        this->set_size(ui::size::all, &size);
+        this->set_size(ui::size::all, size);
     }
 }
 
@@ -224,15 +224,22 @@ int ui::label::get(GLuint e, GLuint t, void *v) const
     }
 }
 
-void ui::label::set(GLuint e, GLuint t, const void *v)
+void ui::label::set(GLuint e, GLuint t, const ui::base_font *v)
 {
-    switch (e)
-    {
-      case ui::element::font:    this->set_font(t, v);      break;
-      case ui::element::string:  this->set_string(t, v);    break;
-      case ui::element::image:   this->set_image(t, v);     break;
-      default:                   ui::widget::set(e, t, v);  break;
-    }
+    if (e == ui::element::font)
+        this->set_font(t, v);
+}
+
+void ui::label::set(GLuint e, GLuint t, const std::string& v)
+{
+    if (e == ui::element::string)
+        this->set_string(t, v);
+}
+
+void ui::label::set(GLuint e, GLuint t, const ui::image& v)
+{
+    if (e == ui::element::image)
+        this->set_image(t, v);
 }
 
 void ui::label::draw(GLuint trans_uniform, const glm::mat4& parent_trans)

--- a/label.h
+++ b/label.h
@@ -1,6 +1,6 @@
 /* label.h                                                 -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 28 Jul 2018, 07:48:08 tquirk
+ *   last updated 12 Aug 2018, 07:04:28 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -70,6 +70,9 @@ namespace ui
 
         virtual int get(GLuint, GLuint, void *) const override;
         virtual void set(GLuint, GLuint, const void *) override;
+
+        GET_VA;
+        SET_VA;
 
         virtual void draw(GLuint, const glm::mat4&) override;
     };

--- a/label.h
+++ b/label.h
@@ -1,6 +1,6 @@
 /* label.h                                                 -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 12 Aug 2018, 07:04:28 tquirk
+ *   last updated 04 Sep 2018, 06:45:45 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -51,13 +51,13 @@ namespace ui
         GLuint tex;
 
         int get_font(GLuint, void *) const;
-        virtual void set_font(GLuint, const void *);
+        virtual void set_font(GLuint, const ui::base_font *);
         int get_string(GLuint, void *) const;
-        virtual void set_string(GLuint, const void *);
+        virtual void set_string(GLuint, const std::string&);
         int get_image(GLuint, void *) const;
-        virtual void set_image(GLuint, const void *);
-        virtual void set_border(GLuint, const void *) override;
-        virtual void set_margin(GLuint, const void *) override;
+        virtual void set_image(GLuint, const ui::image&);
+        virtual void set_border(GLuint, GLuint) override;
+        virtual void set_margin(GLuint, GLuint) override;
 
         virtual void generate_string_image(void);
         virtual void calculate_widget_size(void);
@@ -69,7 +69,10 @@ namespace ui
         virtual ~label();
 
         virtual int get(GLuint, GLuint, void *) const override;
-        virtual void set(GLuint, GLuint, const void *) override;
+        using ui::widget::set;
+        virtual void set(GLuint, GLuint, const ui::base_font *);
+        virtual void set(GLuint, GLuint, const std::string&);
+        virtual void set(GLuint, GLuint, const ui::image&);
 
         GET_VA;
         SET_VA;

--- a/manager.cc
+++ b/manager.cc
@@ -1,6 +1,6 @@
 /* manager.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Jul 2018, 09:25:40 tquirk
+ *   last updated 10 Aug 2018, 22:39:27 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -113,8 +113,8 @@ glm::ivec2 ui::manager::calculate_max_point(void)
     {
         glm::ivec2 c_sz, c_pos;
 
-        (*i)->get_va(ui::element::size, ui::size::all, &c_sz,
-                     ui::element::position, ui::position::all, &c_pos, 0);
+        (*i)->get(ui::element::size, ui::size::all, &c_sz,
+                  ui::element::position, ui::position::all, &c_pos);
         c_sz += c_pos;
         max_pt.x = std::max(max_pt.x, c_sz.x);
         max_pt.y = std::max(max_pt.y, c_sz.y);

--- a/manager.cc
+++ b/manager.cc
@@ -1,6 +1,6 @@
 /* manager.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 10 Aug 2018, 22:39:27 tquirk
+ *   last updated 06 Sep 2018, 09:56:25 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -58,32 +58,33 @@ int ui::manager::get_child_spacing(GLuint t, void *v) const
     return ret;
 }
 
-void ui::manager::set_child_spacing(GLuint t, const void *v)
+void ui::manager::set_child_spacing(GLuint t, GLuint v)
 {
     switch (t)
     {
-      case ui::size::all:
-        this->child_spacing = *reinterpret_cast<const glm::ivec2 *>(v);
-        break;
-      case ui::size::width:
-        this->child_spacing.x = *reinterpret_cast<const int *>(v);
-        break;
-      case ui::size::height:
-        this->child_spacing.y = *reinterpret_cast<const int *>(v);
-        break;
+      case ui::size::width:   this->child_spacing.x = v;  break;
+      case ui::size::height:  this->child_spacing.y = v;  break;
+      default:                                            return;
     }
     this->reposition_children();
     this->regenerate_search_tree();
     this->populate_buffers();
 }
 
-void ui::manager::set_resize(GLuint t, const void *v)
+void ui::manager::set_child_spacing(GLuint t, const glm::ivec2& v)
 {
-    GLuint new_v = *reinterpret_cast<const GLuint *>(v);
+    if (t == ui::size::all)
+    {
+        this->child_spacing = v;
+        this->reposition_children();
+        this->regenerate_search_tree();
+        this->populate_buffers();
+    }
+}
 
-    if (new_v <= ui::resize::all)
-        this->resize = new_v;
-
+void ui::manager::set_resize(GLuint t, GLuint v)
+{
+    this->composite::set_resize(t, v);
     this->set_desired_size();
 }
 
@@ -92,7 +93,13 @@ int ui::manager::get_size(GLuint t, void *v) const
     return this->composite::get_size(t, v);
 }
 
-void ui::manager::set_size(GLuint t, const void *v)
+void ui::manager::set_size(GLuint t, GLuint v)
+{
+    this->composite::set_size(t, v);
+    this->widget::set_size(t, v);
+}
+
+void ui::manager::set_size(GLuint t, const glm::ivec2& v)
 {
     this->composite::set_size(t, v);
     this->widget::set_size(t, v);
@@ -205,15 +212,19 @@ int ui::manager::get(GLuint e, GLuint t, void *v) const
     return 1;
 }
 
-void ui::manager::set(GLuint e, GLuint t, const void *v)
+void ui::manager::set(GLuint e, GLuint t, GLuint v)
 {
     switch (e)
     {
       case ui::element::child_spacing:  this->set_child_spacing(t, v);  break;
-      case ui::element::resize:
-      case ui::element::pixel_size:     this->composite::set(e, t, v);  break;
+      case ui::element::resize:         this->composite::set(e, t, v);  break;
       default:                          this->widget::set(e, t, v);     break;
     }
+}
+
+void ui::manager::set(GLuint e, GLuint t, const glm::ivec2& v)
+{
+    this->widget::set(e, t, v);
 }
 
 void ui::manager::draw(GLuint trans_uniform, const glm::mat4& parent_trans)

--- a/manager.h
+++ b/manager.h
@@ -1,6 +1,6 @@
 /* manager.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 28 Jul 2018, 07:58:02 tquirk
+ *   last updated 12 Aug 2018, 07:04:45 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -59,6 +59,9 @@ namespace ui
 
         virtual int get(GLuint, GLuint, void *) const override;
         virtual void set(GLuint, GLuint, const void *) override;
+
+        GET_VA;
+        SET_VA;
 
         virtual void draw(GLuint, const glm::mat4&) override;
     };

--- a/manager.h
+++ b/manager.h
@@ -1,6 +1,6 @@
 /* manager.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 12 Aug 2018, 07:04:45 tquirk
+ *   last updated 02 Sep 2018, 09:34:51 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -42,10 +42,12 @@ namespace ui
         glm::ivec2 child_spacing;
 
         int get_child_spacing(GLuint, void *) const;
-        void set_child_spacing(GLuint, const void *);
-        virtual void set_resize(GLuint, const void *) override;
+        void set_child_spacing(GLuint, GLuint);
+        void set_child_spacing(GLuint, const glm::ivec2&);
+        virtual void set_resize(GLuint, GLuint) override;
         virtual int get_size(GLuint, void *) const override;
-        virtual void set_size(GLuint, const void *) override;
+        virtual void set_size(GLuint, GLuint) override;
+        virtual void set_size(GLuint, const glm::ivec2&) override;
         virtual int get_pixel_size(GLuint, void *) const override;
 
         glm::ivec2 calculate_max_point(void);
@@ -58,7 +60,10 @@ namespace ui
         virtual ~manager();
 
         virtual int get(GLuint, GLuint, void *) const override;
-        virtual void set(GLuint, GLuint, const void *) override;
+        using ui::widget::set;
+        using ui::composite::set;
+        virtual void set(GLuint, GLuint, GLuint) override;
+        virtual void set(GLuint, GLuint, const glm::ivec2&) override;
 
         GET_VA;
         SET_VA;

--- a/pie_menu.cc
+++ b/pie_menu.cc
@@ -1,6 +1,6 @@
 /* pie_menu.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Jul 2018, 09:26:16 tquirk
+ *   last updated 10 Aug 2018, 23:04:35 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -84,8 +84,8 @@ void ui::pie_menu::show(ui::active *a, void *call, void *client)
         glm::ivec2 new_loc(bcd->location);
         new_loc.x -= pm->dim.x / 2;
         new_loc.y -= pm->dim.y / 2;
-        pm->set_va(ui::element::position, ui::position::all, &new_loc,
-                   ui::element::state, ui::state::visible, &t, 0);
+        pm->set(ui::element::position, ui::position::all, &new_loc,
+                ui::element::state, ui::state::visible, &t);
         pm->composite::parent->move_child(pm);
     }
 }

--- a/pie_menu.cc
+++ b/pie_menu.cc
@@ -1,6 +1,6 @@
 /* pie_menu.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 10 Aug 2018, 23:04:35 tquirk
+ *   last updated 02 Sep 2018, 15:13:06 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -58,13 +58,13 @@ int ui::pie_menu::get_popup(GLuint t, void *v) const
     return ret;
 }
 
-void ui::pie_menu::set_popup(GLuint t, const void *v)
+void ui::pie_menu::set_popup(GLuint t, GLuint v)
 {
     if (t == ui::popup::button)
-        this->popup_button = *reinterpret_cast<const int *>(v);
+        this->popup_button = v;
 }
 
-void ui::pie_menu::set_resize(GLuint t, const void *v)
+void ui::pie_menu::set_resize(GLuint t, GLuint v)
 {
     /* No-op, since we don't want this to change */
 }
@@ -80,12 +80,11 @@ void ui::pie_menu::show(ui::active *a, void *call, void *client)
 
     if (bcd->button == pm->popup_button && bcd->state == ui::mouse::down)
     {
-        bool t = true;
         glm::ivec2 new_loc(bcd->location);
         new_loc.x -= pm->dim.x / 2;
         new_loc.y -= pm->dim.y / 2;
-        pm->set(ui::element::position, ui::position::all, &new_loc,
-                ui::element::state, ui::state::visible, &t);
+        pm->set(ui::element::position, ui::position::all, new_loc,
+                ui::element::state, ui::state::visible, true);
         pm->composite::parent->move_child(pm);
     }
 }
@@ -100,10 +99,7 @@ void ui::pie_menu::hide(ui::active *a, void *call, void *client)
     ui::btn_call_data *bcd = (ui::btn_call_data *)call;
 
     if (bcd->button == pm->popup_button && bcd->state == ui::mouse::up)
-    {
-        bool f = false;
-        pm->set(ui::element::state, ui::state::visible, &f);
-    }
+        pm->set(ui::element::state, ui::state::visible, false);
 }
 
 void ui::pie_menu::set_desired_size(void)
@@ -130,7 +126,7 @@ void ui::pie_menu::set_desired_size(void)
                 - (child_size.x / 2);
             child_pos.y = center.y + (int)truncf((float)middle.y * sin(angle))
                 - (child_size.y / 2);
-            (*child)->set(ui::element::position, ui::position::all, &child_pos);
+            (*child)->set(ui::element::position, ui::position::all, child_pos);
         }
     }
     this->dirty = false;
@@ -276,7 +272,7 @@ int ui::pie_menu::get(GLuint e, GLuint t, void *v) const
     return this->manager::get(e, t, v);
 }
 
-void ui::pie_menu::set(GLuint e, GLuint t, const void *v)
+void ui::pie_menu::set(GLuint e, GLuint t, GLuint v)
 {
     if (e == ui::element::popup)
         this->set_popup(t, v);

--- a/pie_menu.h
+++ b/pie_menu.h
@@ -1,6 +1,6 @@
 /* pie_menu.h                                              -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 28 Jul 2018, 08:01:58 tquirk
+ *   last updated 12 Aug 2018, 07:04:59 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -60,6 +60,9 @@ namespace ui
 
         virtual int get(GLuint, GLuint, void *) const override;
         virtual void set(GLuint, GLuint, const void *) override;
+
+        GET_VA;
+        SET_VA;
 
         virtual void mouse_pos_callback(glm::ivec2&) override;
         virtual void mouse_btn_callback(ui::btn_call_data&) override;

--- a/pie_menu.h
+++ b/pie_menu.h
@@ -1,6 +1,6 @@
 /* pie_menu.h                                              -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 12 Aug 2018, 07:04:59 tquirk
+ *   last updated 02 Sep 2018, 15:07:45 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -41,8 +41,8 @@ namespace ui
         int popup_button;
 
         int get_popup(GLuint, void *) const;
-        void set_popup(GLuint, const void *);
-        virtual void set_resize(GLuint, const void *) override;
+        void set_popup(GLuint, GLuint);
+        virtual void set_resize(GLuint, GLuint) final;
 
         static void show(active *, void *, void *);
         static void hide(active *, void *, void *);
@@ -59,7 +59,8 @@ namespace ui
         virtual ~pie_menu();
 
         virtual int get(GLuint, GLuint, void *) const override;
-        virtual void set(GLuint, GLuint, const void *) override;
+        using ui::manager::set;
+        virtual void set(GLuint, GLuint, GLuint) override;
 
         GET_VA;
         SET_VA;

--- a/quadtree.cc
+++ b/quadtree.cc
@@ -1,6 +1,6 @@
 /* quadtree.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 09 Oct 2016, 14:43:09 tquirk
+ *   last updated 10 Aug 2018, 23:05:43 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2016  Trinity Annabelle Quirk
@@ -42,8 +42,8 @@ int ui::quadtree::classify(ui::widget *p)
     glm::ivec2 ul, lr;
     int retval = 0;
 
-    p->get_va(ui::element::position, ui::position::all, &ul,
-              ui::element::size, ui::size::all, &lr, 0);
+    p->get(ui::element::position, ui::position::all, &ul,
+           ui::element::size, ui::size::all, &lr);
     /* Width and height are not absolute screen coords */
     lr += ul;
     retval |= this->quad_mask(ul);
@@ -158,8 +158,8 @@ ui::widget *ui::quadtree::search(const glm::ivec2& pt)
     {
         glm::ivec2 ul, lr;
 
-        (*i)->get_va(ui::element::position, ui::position::all, &ul,
-                     ui::element::size, ui::size::all, &lr, 0);
+        (*i)->get(ui::element::position, ui::position::all, &ul,
+                  ui::element::size, ui::size::all, &lr);
         lr += ul;
         if (pt.x >= ul.x && pt.x < lr.x && pt.y >= ul.y && pt.y < lr.y)
             return *i;

--- a/rect.cc
+++ b/rect.cc
@@ -1,6 +1,6 @@
 /* rect.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 10 Aug 2018, 23:48:28 tquirk
+ *   last updated 06 Sep 2018, 09:26:51 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -52,19 +52,20 @@ int ui::rect::get_size(GLuint t, void *v) const
     return ret;
 }
 
-void ui::rect::set_size(GLuint t, const void *v)
+void ui::rect::set_size(GLuint t, GLuint v)
 {
     switch (t)
     {
-      case ui::size::all:
-        this->dim = *reinterpret_cast<const glm::ivec2 *>(v);
-        break;
-      case ui::size::width:
-        this->dim.x = *reinterpret_cast<const int *>(v);
-        break;
-      case ui::size::height:
-        this->dim.y = *reinterpret_cast<const int *>(v);
-        break;
+      case ui::size::width:   this->dim.x = v;  break;
+      case ui::size::height:  this->dim.y = v;  break;
+    }
+}
+
+void ui::rect::set_size(GLuint t, const glm::ivec2& v)
+{
+    switch (t)
+    {
+      case ui::size::all:  this->dim = v;  break;
     }
 }
 
@@ -86,7 +87,18 @@ int ui::rect::get(GLuint e, GLuint t, void *v) const
     return ret;
 }
 
-void ui::rect::set(GLuint e, GLuint t, const void *v)
+void ui::rect::set(GLuint e, GLuint t, int v)
+{
+    this->set(e, t, (GLuint)v);
+}
+
+void ui::rect::set(GLuint e, GLuint t, GLuint v)
+{
+    if (e == ui::element::size)
+        this->set_size(t, v);
+}
+
+void ui::rect::set(GLuint e, GLuint t, const glm::ivec2& v)
 {
     if (e == ui::element::size)
         this->set_size(t, v);

--- a/rect.cc
+++ b/rect.cc
@@ -1,6 +1,6 @@
 /* rect.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 05 Aug 2018, 08:11:37 tquirk
+ *   last updated 10 Aug 2018, 23:48:28 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -90,36 +90,4 @@ void ui::rect::set(GLuint e, GLuint t, const void *v)
 {
     if (e == ui::element::size)
         this->set_size(t, v);
-}
-
-void ui::rect::get_va(GLuint e, GLuint t, void *v, ...) const
-{
-    va_list args;
-    GLuint item[2];
-
-    this->get(e, t, v);
-    va_start(args, v);
-    while ((item[0] = va_arg(args, GLuint)) != 0)
-    {
-        item[1] = va_arg(args, GLuint);
-        void *ptr = va_arg(args, void *);
-        this->get(item[0], item[1], ptr);
-    }
-    va_end(args);
-}
-
-void ui::rect::set_va(GLuint e, GLuint t, const void *v, ...)
-{
-    va_list args;
-    GLuint item[2];
-
-    this->set(e, t, v);
-    va_start(args, v);
-    while ((item[0] = va_arg(args, GLuint)) != 0)
-    {
-        item[1] = va_arg(args, GLuint);
-        void *ptr = va_arg(args, void *);
-        this->set(item[0], item[1], ptr);
-    }
-    va_end(args);
 }

--- a/rect.h
+++ b/rect.h
@@ -1,6 +1,6 @@
 /* rect.h                                                  -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 28 Jul 2018, 07:53:52 tquirk
+ *   last updated 12 Aug 2018, 07:05:14 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -30,8 +30,6 @@
 #ifndef __INC_CUDDLY_RECT_H__
 #define __INC_CUDDLY_RECT_H__
 
-#include <stdarg.h>
-
 #include <GL/gl.h>
 
 #include <glm/vec2.hpp>
@@ -52,8 +50,9 @@ namespace ui
 
         virtual int get(GLuint, GLuint, void *) const;
         virtual void set(GLuint, GLuint, const void *);
-        void get_va(GLuint, GLuint, void *, ...) const;
-        void set_va(GLuint, GLuint, const void *, ...);
+
+        GET_VA;
+        SET_VA;
     };
 }
 

--- a/rect.h
+++ b/rect.h
@@ -1,6 +1,6 @@
 /* rect.h                                                  -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 12 Aug 2018, 07:05:14 tquirk
+ *   last updated 04 Sep 2018, 07:06:50 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -42,14 +42,17 @@ namespace ui
         glm::ivec2 dim;
 
         virtual int get_size(GLuint, void *) const;
-        virtual void set_size(GLuint, const void *);
+        virtual void set_size(GLuint, GLuint);
+        virtual void set_size(GLuint, const glm::ivec2&);
 
       public:
         rect(GLuint, GLuint);
         virtual ~rect();
 
         virtual int get(GLuint, GLuint, void *) const;
-        virtual void set(GLuint, GLuint, const void *);
+        virtual void set(GLuint, GLuint, int);
+        virtual void set(GLuint, GLuint, GLuint);
+        virtual void set(GLuint, GLuint, const glm::ivec2&);
 
         GET_VA;
         SET_VA;

--- a/row_column.cc
+++ b/row_column.cc
@@ -1,6 +1,6 @@
 /* row_column.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Jul 2018, 09:57:57 tquirk
+ *   last updated 02 Sep 2018, 13:29:08 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -59,26 +59,22 @@ int ui::row_column::get_size(GLuint t, void *v) const
     return ret;
 }
 
-void ui::row_column::set_size(GLuint t, const void *v)
+void ui::row_column::set_size(GLuint t, GLuint v)
 {
     switch (t)
     {
-      case ui::size::all:
-      case ui::size::width:
-      case ui::size::height:
-        this->manager::set_size(t, v);
-        break;
-
-      case ui::size::grid:
-        this->grid_sz = *reinterpret_cast<const glm::ivec2 *>(v);
-        break;
-      case ui::size::rows:
-        this->grid_sz.y = *reinterpret_cast<const int *>(v);
-        break;
-      case ui::size::columns:
-        this->grid_sz.x = *reinterpret_cast<const int *>(v);
-        break;
+      case ui::size::rows:     this->grid_sz.y = v;  break;
+      case ui::size::columns:  this->grid_sz.x = v;  break;
+      default:                 this->manager::set_size(t, v);
     }
+}
+
+void ui::row_column::set_size(GLuint t, const glm::ivec2& v)
+{
+    if (t == ui::size::grid)
+        this->grid_sz = v;
+    else
+        this->manager::set_size(t, v);
 }
 
 int ui::row_column::get_order(GLuint t, void *v) const
@@ -87,12 +83,10 @@ int ui::row_column::get_order(GLuint t, void *v) const
     return 0;
 }
 
-void ui::row_column::set_order(GLuint t, const void *v)
+void ui::row_column::set_order(GLuint t, GLuint v)
 {
-    GLuint new_v = *reinterpret_cast<const GLuint *>(v);
-
-    if (new_v == ui::order::row || new_v == ui::order::column)
-        this->pack_order = new_v;
+    if (v == ui::order::row || v == ui::order::column)
+        this->pack_order = v;
 }
 
 glm::ivec2 ui::row_column::calculate_cell_size(void)
@@ -183,7 +177,7 @@ void ui::row_column::insert_row_major(glm::ivec2& grid, glm::ivec2& cell)
         for (int j = 0; j < grid.x; ++j)
         {
             cur_pos.x = pos.x + ((cell.x + this->child_spacing.x) * j);
-            (*c)->set(ui::element::position, ui::position::all, &cur_pos);
+            (*c)->set(ui::element::position, ui::position::all, cur_pos);
 
             if (++c == this->children.end())
                 return;
@@ -204,7 +198,7 @@ void ui::row_column::insert_column_major(glm::ivec2& grid, glm::ivec2& cell)
         for (int j = 0; j < grid.y; ++j)
         {
             cur_pos.y = pos.y + ((cell.y + this->child_spacing.y) * j);
-            (*c)->set(ui::element::position, ui::position::all, &cur_pos);
+            (*c)->set(ui::element::position, ui::position::all, cur_pos);
 
             if (++c == this->children.end())
                 return;
@@ -230,7 +224,7 @@ int ui::row_column::get(GLuint e, GLuint t, void *v) const
     return this->manager::get(e, t, v);
 }
 
-void ui::row_column::set(GLuint e, GLuint t, const void *v)
+void ui::row_column::set(GLuint e, GLuint t, GLuint v)
 {
     if (e == ui::element::order)
         this->set_order(t, v);

--- a/row_column.h
+++ b/row_column.h
@@ -1,6 +1,6 @@
 /* row_column.h                                            -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 12 Aug 2018, 07:05:29 tquirk
+ *   last updated 02 Sep 2018, 13:29:03 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -41,9 +41,11 @@ namespace ui
         GLuint pack_order;
 
         virtual int get_size(GLuint, void *) const override;
-        virtual void set_size(GLuint, const void *) override;
+        using ui::manager::set_size;
+        virtual void set_size(GLuint, GLuint) override;
+        virtual void set_size(GLuint, const glm::ivec2&) override;
         virtual int get_order(GLuint, void *) const;
-        virtual void set_order(GLuint, const void *);
+        virtual void set_order(GLuint, GLuint);
 
         glm::ivec2 calculate_cell_size(void);
         glm::ivec2 calculate_grid_size(void);
@@ -56,7 +58,8 @@ namespace ui
         virtual ~row_column();
 
         virtual int get(GLuint, GLuint, void *) const override;
-        virtual void set(GLuint, GLuint, const void *) override;
+        using ui::manager::set;
+        virtual void set(GLuint, GLuint, GLuint) override;
 
         GET_VA;
         SET_VA;

--- a/row_column.h
+++ b/row_column.h
@@ -1,6 +1,6 @@
 /* row_column.h                                            -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 28 Jul 2018, 08:04:54 tquirk
+ *   last updated 12 Aug 2018, 07:05:29 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -57,6 +57,9 @@ namespace ui
 
         virtual int get(GLuint, GLuint, void *) const override;
         virtual void set(GLuint, GLuint, const void *) override;
+
+        GET_VA;
+        SET_VA;
     };
 }
 

--- a/test/t_rect.cc
+++ b/test/t_rect.cc
@@ -118,28 +118,28 @@ void test_set_size(void)
     }
 
     st = "set_size single: ";
-    r->set_size(ui::size::height, &dim);
+    r->set_size(ui::size::height, dim);
     is(r->dim.y, 42, test + st + "expected height");
 
     st = "set_size vector: ";
-    r->set_size(ui::size::all, &sz);
+    r->set_size(ui::size::all, sz);
     is(r->dim.x, 6, test + st + "expected x-dim");
     is(r->dim.y, 5, test + st + "expected y-dim");
 
     st = "set_size bad element subtype: ";
     dim = 9876;
-    r->set_size(-1, &dim);
+    r->set_size(-1, dim);
     is(r->dim.x, 6, test + st + "x-dim unchanged");
     is(r->dim.y, 5, test + st + "y-dim unchanged");
 
     st = "set single: ";
     dim = 42;
-    r->set(ui::element::size, ui::size::width, &dim);
+    r->set(ui::element::size, ui::size::width, dim);
     is(r->dim.x, 42, test + st + "expected width");
 
     st = "set bad element type: ";
     dim = 9876;
-    r->set(-1, ui::size::width, &dim);
+    r->set(-1, ui::size::width, dim);
     isnt(r->dim.x, 9876, test + st + "width unchanged");
 
     try
@@ -216,22 +216,22 @@ void test_va_set(void)
     }
 
     st = "single: ";
-    r->set(ui::element::size, ui::size::width, &dim,
-           ui::element::size, ui::size::height, &dim);
+    r->set(ui::element::size, ui::size::width, dim,
+           ui::element::size, ui::size::height, dim);
     is(r->dim.x, dim, test + st + "expected width");
     is(r->dim.y, dim, test + st + "expected height");
 
     st = "vector: ";
-    r->set(ui::element::size, ui::size::all, &sz);
+    r->set(ui::element::size, ui::size::all, sz);
     is(r->dim.x, sz.x, test + st + "expected width");
     is(r->dim.y, sz.y, test + st + "expected height");
 
     st = "bad element type: ";
-    r->set(99999, ui::size::width, &dim);
+    r->set(99999, ui::size::width, dim);
     isnt(r->dim.x, dim, test + st + "width unchanged");
 
     st = "bad element subtype: ";
-    r->set(ui::element::size, 99999, &dim);
+    r->set(ui::element::size, 99999, dim);
     isnt(r->dim.x, dim, test + st + "width unchanged");
     isnt(r->dim.y, dim, test + st + "height unchanged");
 

--- a/test/t_rect.cc
+++ b/test/t_rect.cc
@@ -154,7 +154,7 @@ void test_set_size(void)
 
 void test_va_get(void)
 {
-    std::string test = "va_get: ", st;
+    std::string test = "varargs get: ", st;
     test_rect *r = NULL;
     GLuint dim = 0;
     glm::ivec2 sz = {6, 5};
@@ -170,22 +170,22 @@ void test_va_get(void)
     }
 
     st = "single: ";
-    r->get_va(ui::element::size, ui::size::width, &dim,
-              ui::element::size, ui::size::height, &dim, 0);
+    r->get(ui::element::size, ui::size::width, &dim,
+           ui::element::size, ui::size::height, &dim);
     is(dim, 87, test + st + "expected size");
 
     st = "vector: ";
-    r->get_va(ui::element::size, ui::size::all, &sz, 0);
+    r->get(ui::element::size, ui::size::all, &sz);
     is(sz.x, 9, test + st + "expected width");
     is(sz.y, 87, test + st + "expected height");
 
     st = "bad element type: ";
     dim = 4;
-    r->get_va(99999, ui::size::width, &dim, 0);
+    r->get(99999, ui::size::width, &dim);
     is(dim, 4, test + st + "value unchanged");
 
     st = "bad element subtype: ";
-    r->get_va(ui::element::size, 99999, &dim, 0);
+    r->get(ui::element::size, 99999, &dim);
     is(dim, 4, test + st + "value unchanged");
 
     try
@@ -200,7 +200,7 @@ void test_va_get(void)
 
 void test_va_set(void)
 {
-    std::string test = "va_set: ", st;
+    std::string test = "varargs set: ", st;
     test_rect *r = NULL;
     GLuint dim = 42;
     glm::ivec2 sz = {6, 5};
@@ -216,22 +216,22 @@ void test_va_set(void)
     }
 
     st = "single: ";
-    r->set_va(ui::element::size, ui::size::width, &dim,
-              ui::element::size, ui::size::height, &dim, 0);
+    r->set(ui::element::size, ui::size::width, &dim,
+           ui::element::size, ui::size::height, &dim);
     is(r->dim.x, dim, test + st + "expected width");
     is(r->dim.y, dim, test + st + "expected height");
 
     st = "vector: ";
-    r->set_va(ui::element::size, ui::size::all, &sz, 0);
+    r->set(ui::element::size, ui::size::all, &sz);
     is(r->dim.x, sz.x, test + st + "expected width");
     is(r->dim.y, sz.y, test + st + "expected height");
 
     st = "bad element type: ";
-    r->set_va(99999, ui::size::width, &dim, 0);
+    r->set(99999, ui::size::width, &dim);
     isnt(r->dim.x, dim, test + st + "width unchanged");
 
     st = "bad element subtype: ";
-    r->set_va(ui::element::size, 99999, &dim, 0);
+    r->set(ui::element::size, 99999, &dim);
     isnt(r->dim.x, dim, test + st + "width unchanged");
     isnt(r->dim.y, dim, test + st + "height unchanged");
 

--- a/test/uitest.cc
+++ b/test/uitest.cc
@@ -112,108 +112,78 @@ int main(int argc, char **argv)
 
     std::cout << "creating widget 1" << std::endl;
     w1 = new ui::widget(ctx, 50, 50);
-    xpos = 50;
-    ypos = 50;
-    border = 2;
-    w1->set(ui::element::color, ui::color::foreground, &fg1,
-            ui::element::color, ui::color::background, &fg2,
-            ui::element::border, ui::side::all, &border,
-            ui::element::margin, ui::side::all, &border,
-            ui::element::position, ui::position::x, &xpos,
-            ui::element::position, ui::position::y, &ypos);
+    w1->set(ui::element::color, ui::color::foreground, fg1,
+            ui::element::color, ui::color::background, fg2,
+            ui::element::border, ui::side::all, 2,
+            ui::element::margin, ui::side::all, 2,
+            ui::element::position, ui::position::x, 50,
+            ui::element::position, ui::position::y, 50);
     std::cout << "creating label 1" << std::endl;
     l1 = new ui::label(ctx, 0, 0);
-    xpos = 50;
-    ypos = 125;
-    border = 1;
-    l1->set(ui::element::font, ui::ownership::shared, std_font,
-            ui::element::string, 0, &greeting,
-            ui::element::color, ui::color::foreground, &fg1,
-            ui::element::border, ui::side::all, &border,
-            ui::element::margin, ui::side::all, &border,
-            ui::element::position, ui::position::x, &xpos,
-            ui::element::position, ui::position::y, &ypos);
+    l1->set(ui::element::font, ui::ownership::shared, (const ui::base_font *)std_font,
+            ui::element::string, 0, greeting,
+            ui::element::color, ui::color::foreground, fg1,
+            ui::element::border, ui::side::all, 1,
+            ui::element::margin, ui::side::all, 1,
+            ui::element::position, ui::position::x, 50,
+            ui::element::position, ui::position::y, 125);
     std::cout << "creating button 1" << std::endl;
     b1 = new ui::button(ctx, 0, 0);
-    xpos = 50;
-    ypos = 175;
-    border = 0;
-    b1->set(ui::element::image, 0, &img,
-            ui::element::margin, ui::side::all, &border,
-            ui::element::border, ui::side::all, &border,
-            ui::element::color, ui::color::foreground, &fg1,
-            ui::element::color, ui::color::background, &bg3,
-            ui::element::position, ui::position::x, &xpos,
-            ui::element::position, ui::position::y, &ypos);
+    b1->set(ui::element::image, 0, img,
+            ui::element::margin, ui::side::all, 0,
+            ui::element::border, ui::side::all, 0,
+            ui::element::color, ui::color::foreground, fg1,
+            ui::element::color, ui::color::background, bg3,
+            ui::element::position, ui::position::x, 50,
+            ui::element::position, ui::position::y, 175);
     std::cout << "creating password 1" << std::endl;
     pw1 = new ui::password(ctx, 0, 0);
-    xpos = 50;
-    ypos = 250;
-    border = 1;
-    max_len = 5;
-    pw1->set(ui::element::font, ui::ownership::shared, std_font,
-             ui::element::border, ui::side::all, &border,
-             ui::element::color, ui::color::foreground, &fg1,
-             ui::element::color, ui::color::background, &bg2,
-             ui::element::position, ui::position::x, &xpos,
-             ui::element::position, ui::position::y, &ypos,
-             ui::element::size, ui::size::max_width, &max_len);
+    pw1->set(ui::element::font, ui::ownership::shared, (const ui::base_font *)std_font,
+             ui::element::border, ui::side::all, 1,
+             ui::element::color, ui::color::foreground, fg1,
+             ui::element::color, ui::color::background, bg2,
+             ui::element::position, ui::position::x, 50,
+             ui::element::position, ui::position::y, 250,
+             ui::element::size, ui::size::max_width, 5);
     std::cout << "creating manager 1" << std::endl;
     m1 = new ui::manager(ctx, 200, 200);
-    xpos = 250;
-    ypos = 35;
-    border = 1;
-    spacing = 10;
-    m1->set(ui::element::border, ui::side::all, &border,
-            ui::element::color, ui::color::foreground, &fg1,
-            ui::element::color, ui::color::background, &bg2,
-            ui::element::position, ui::position::x, &xpos,
-            ui::element::position, ui::position::y, &ypos,
-            ui::element::child_spacing, ui::size::width, &spacing,
-            ui::element::child_spacing, ui::size::height, &spacing);
+    m1->set(ui::element::border, ui::side::all, 1,
+            ui::element::color, ui::color::foreground, fg1,
+            ui::element::color, ui::color::background, bg2,
+            ui::element::position, ui::position::x, 250,
+            ui::element::position, ui::position::y, 35,
+            ui::element::child_spacing, ui::size::width, 10,
+            ui::element::child_spacing, ui::size::height, 10);
     std::cout << "creating button 2" << std::endl;
     b2 = new ui::button(m1, 0, 0);
-    xpos = 10;
-    ypos = 10;
-    border = 5;
-    b2->set(ui::element::font, ui::ownership::shared, std_font,
-            ui::element::color, ui::color::foreground, &fg2,
-            ui::element::string, 0, &greeting,
-            ui::element::margin, ui::side::all, &border,
-            ui::element::border, ui::side::all, &border,
-            ui::element::position, ui::position::x, &xpos,
-            ui::element::position, ui::position::y, &ypos);
+    b2->set(ui::element::font, ui::ownership::shared, (const ui::base_font *)std_font,
+            ui::element::color, ui::color::foreground, fg2,
+            ui::element::string, 0, greeting,
+            ui::element::margin, ui::side::all, 5,
+            ui::element::border, ui::side::all, 5,
+            ui::element::position, ui::position::x, 10,
+            ui::element::position, ui::position::y, 10);
     std::cout << "creating text field 1" << std::endl;
     t1 = new ui::text_field(m1, 0, 0);
-    xpos = 10;
-    ypos = 100;
-    border = 1;
-    max_len = 10;
-    t1->set(ui::element::font, ui::ownership::shared, std_font,
-            ui::element::string, 0, &greeting,
-            ui::element::size, ui::size::max_width, &max_len,
-            ui::element::border, ui::side::all, &border,
-            ui::element::color, ui::color::foreground, &fg1,
-            ui::element::color, ui::color::background, &bg1,
-            ui::element::position, ui::position::x, &xpos,
-            ui::element::position, ui::position::y, &ypos);
+    t1->set(ui::element::font, ui::ownership::shared, (const ui::base_font *)std_font,
+            ui::element::string, 0, greeting,
+            ui::element::size, ui::size::max_width, 10,
+            ui::element::border, ui::side::all, 1,
+            ui::element::color, ui::color::foreground, fg1,
+            ui::element::color, ui::color::background, bg1,
+            ui::element::position, ui::position::x, 10,
+            ui::element::position, ui::position::y, 100);
     std::cout << "creating row-column 1" << std::endl;
     r1 = new ui::row_column(ctx, 10, 10);
-    xpos = 520;
-    ypos = 35;
-    border = 1;
-    gridx = 1;
-    gridy = 0;
-    spacing = 10;
-    r1->set(ui::element::border, ui::side::all, &border,
-            ui::element::size, ui::size::columns, &gridx,
-            ui::element::size, ui::size::rows, &gridy,
-            ui::element::color, ui::color::foreground, &fg1,
-            ui::element::color, ui::color::background, &bg1,
-            ui::element::position, ui::position::x, &xpos,
-            ui::element::position, ui::position::y, &ypos,
-            ui::element::child_spacing, ui::size::width, &spacing,
-            ui::element::child_spacing, ui::size::height, &spacing);
+    r1->set(ui::element::border, ui::side::all, 1,
+            ui::element::size, ui::size::columns, 1,
+            ui::element::size, ui::size::rows, 0,
+            ui::element::color, ui::color::foreground, fg1,
+            ui::element::color, ui::color::background, bg1,
+            ui::element::position, ui::position::x, 520,
+            ui::element::position, ui::position::y, 35,
+            ui::element::child_spacing, ui::size::width, 10,
+            ui::element::child_spacing, ui::size::height, 10);
     r1->add_callback(ui::callback::btn_down, reorient_callback, NULL);
     for (int q = 0; q < 7; ++q)
     {
@@ -222,23 +192,18 @@ int main(int argc, char **argv)
         ui::label *l = new ui::label(r1, 0, 0);
 
         s << "Label " << q << "\n" << greeting;
-        std::string str = s.str();
-        border = 1;
-        wid = 100;
-        l->set(ui::element::font, ui::ownership::shared, std_font,
-               ui::element::string, 0, &str,
-               ui::element::border, ui::side::all, &border,
-               ui::element::size, ui::size::width, &wid);
+        l->set(ui::element::font, ui::ownership::shared, (const ui::base_font *)std_font,
+               ui::element::string, 0, s.str(),
+               ui::element::border, ui::side::all, 1,
+               ui::element::size, ui::size::width, 100);
         l->add_callback(ui::callback::btn_down, print_sizes, NULL);
     }
     std::cout << "creating popup 1" << std::endl;
     pu1 = new ui::pie_menu(ctx, 200, 125);
-    border = 1;
-    button = ui::mouse::button0;
-    pu1->set(ui::element::border, ui::side::outer, &border,
-             ui::element::margin, ui::side::outer, &border,
-             ui::element::border, ui::side::inner, &border,
-             ui::element::popup, ui::popup::button, &button);
+    pu1->set(ui::element::border, ui::side::outer, 1,
+             ui::element::margin, ui::side::outer, 1,
+             ui::element::border, ui::side::inner, 1,
+             ui::element::popup, ui::popup::button, ui::mouse::button0);
     for (intptr_t q = 0; q < 7; ++q)
     {
         std::cout << "  creating child " << q << std::endl;
@@ -246,9 +211,8 @@ int main(int argc, char **argv)
         ui::label *pul = new ui::label(pu1, 0, 0);
 
         s << (char)('a' + q);
-        std::string str = s.str();
-        pul->set(ui::element::font, ui::ownership::shared, tiny_font,
-                 ui::element::string, 0, &str);
+        pul->set(ui::element::font, ui::ownership::shared, (const ui::base_font *)tiny_font,
+                 ui::element::string, 0, s.str());
         pul->add_callback(ui::callback::btn_up, menu_callback, (void *)q);
         pul->add_callback(ui::callback::enter, enter_callback, (void *)q);
         pul->add_callback(ui::callback::leave, leave_callback, (void *)q);
@@ -279,7 +243,7 @@ void window_size_callback(GLFWwindow *w, int width, int height)
 {
     glm::ivec2 sz(width, height);
 
-    ctx->set(ui::element::size, ui::size::all, &sz);
+    ctx->set(ui::element::size, ui::size::all, sz);
 }
 
 void create_image(int width, int height)
@@ -336,8 +300,8 @@ void reorient_callback(ui::active *a, void *call, void *client)
 
         r->get(ui::element::size, ui::size::grid, &old_grid,
                ui::element::order, 0, &old_orient);
-        r->set(ui::element::size, ui::size::grid, &grid,
-               ui::element::order, 0, &orient);
+        r->set(ui::element::size, ui::size::grid, grid,
+               ui::element::order, 0, orient);
         r->manage_children();
         grid = old_grid;
         orient = old_orient;

--- a/test/uitest.cc
+++ b/test/uitest.cc
@@ -115,88 +115,88 @@ int main(int argc, char **argv)
     xpos = 50;
     ypos = 50;
     border = 2;
-    w1->set_va(ui::element::color, ui::color::foreground, &fg1,
-               ui::element::color, ui::color::background, &fg2,
-               ui::element::border, ui::side::all, &border,
-               ui::element::margin, ui::side::all, &border,
-               ui::element::position, ui::position::x, &xpos,
-               ui::element::position, ui::position::y, &ypos, 0);
+    w1->set(ui::element::color, ui::color::foreground, &fg1,
+            ui::element::color, ui::color::background, &fg2,
+            ui::element::border, ui::side::all, &border,
+            ui::element::margin, ui::side::all, &border,
+            ui::element::position, ui::position::x, &xpos,
+            ui::element::position, ui::position::y, &ypos);
     std::cout << "creating label 1" << std::endl;
     l1 = new ui::label(ctx, 0, 0);
     xpos = 50;
     ypos = 125;
     border = 1;
-    l1->set_va(ui::element::font, ui::ownership::shared, std_font,
-               ui::element::string, 0, &greeting,
-               ui::element::color, ui::color::foreground, &fg1,
-               ui::element::border, ui::side::all, &border,
-               ui::element::margin, ui::side::all, &border,
-               ui::element::position, ui::position::x, &xpos,
-               ui::element::position, ui::position::y, &ypos, 0);
+    l1->set(ui::element::font, ui::ownership::shared, std_font,
+            ui::element::string, 0, &greeting,
+            ui::element::color, ui::color::foreground, &fg1,
+            ui::element::border, ui::side::all, &border,
+            ui::element::margin, ui::side::all, &border,
+            ui::element::position, ui::position::x, &xpos,
+            ui::element::position, ui::position::y, &ypos);
     std::cout << "creating button 1" << std::endl;
     b1 = new ui::button(ctx, 0, 0);
     xpos = 50;
     ypos = 175;
     border = 0;
-    b1->set_va(ui::element::image, 0, &img,
-               ui::element::margin, ui::side::all, &border,
-               ui::element::border, ui::side::all, &border,
-               ui::element::color, ui::color::foreground, &fg1,
-               ui::element::color, ui::color::background, &bg3,
-               ui::element::position, ui::position::x, &xpos,
-               ui::element::position, ui::position::y, &ypos, 0);
+    b1->set(ui::element::image, 0, &img,
+            ui::element::margin, ui::side::all, &border,
+            ui::element::border, ui::side::all, &border,
+            ui::element::color, ui::color::foreground, &fg1,
+            ui::element::color, ui::color::background, &bg3,
+            ui::element::position, ui::position::x, &xpos,
+            ui::element::position, ui::position::y, &ypos);
     std::cout << "creating password 1" << std::endl;
     pw1 = new ui::password(ctx, 0, 0);
     xpos = 50;
     ypos = 250;
     border = 1;
     max_len = 5;
-    pw1->set_va(ui::element::font, ui::ownership::shared, std_font,
-                ui::element::border, ui::side::all, &border,
-                ui::element::color, ui::color::foreground, &fg1,
-                ui::element::color, ui::color::background, &bg2,
-                ui::element::position, ui::position::x, &xpos,
-                ui::element::position, ui::position::y, &ypos,
-                ui::element::size, ui::size::max_width, &max_len, 0);
+    pw1->set(ui::element::font, ui::ownership::shared, std_font,
+             ui::element::border, ui::side::all, &border,
+             ui::element::color, ui::color::foreground, &fg1,
+             ui::element::color, ui::color::background, &bg2,
+             ui::element::position, ui::position::x, &xpos,
+             ui::element::position, ui::position::y, &ypos,
+             ui::element::size, ui::size::max_width, &max_len);
     std::cout << "creating manager 1" << std::endl;
     m1 = new ui::manager(ctx, 200, 200);
     xpos = 250;
     ypos = 35;
     border = 1;
     spacing = 10;
-    m1->set_va(ui::element::border, ui::side::all, &border,
-               ui::element::color, ui::color::foreground, &fg1,
-               ui::element::color, ui::color::background, &bg2,
-               ui::element::position, ui::position::x, &xpos,
-               ui::element::position, ui::position::y, &ypos,
-               ui::element::child_spacing, ui::size::width, &spacing,
-               ui::element::child_spacing, ui::size::height, &spacing, 0);
+    m1->set(ui::element::border, ui::side::all, &border,
+            ui::element::color, ui::color::foreground, &fg1,
+            ui::element::color, ui::color::background, &bg2,
+            ui::element::position, ui::position::x, &xpos,
+            ui::element::position, ui::position::y, &ypos,
+            ui::element::child_spacing, ui::size::width, &spacing,
+            ui::element::child_spacing, ui::size::height, &spacing);
     std::cout << "creating button 2" << std::endl;
     b2 = new ui::button(m1, 0, 0);
     xpos = 10;
     ypos = 10;
     border = 5;
-    b2->set_va(ui::element::font, ui::ownership::shared, std_font,
-               ui::element::color, ui::color::foreground, &fg2,
-               ui::element::string, 0, &greeting,
-               ui::element::margin, ui::side::all, &border,
-               ui::element::border, ui::side::all, &border,
-               ui::element::position, ui::position::x, &xpos,
-               ui::element::position, ui::position::y, &ypos, 0);
+    b2->set(ui::element::font, ui::ownership::shared, std_font,
+            ui::element::color, ui::color::foreground, &fg2,
+            ui::element::string, 0, &greeting,
+            ui::element::margin, ui::side::all, &border,
+            ui::element::border, ui::side::all, &border,
+            ui::element::position, ui::position::x, &xpos,
+            ui::element::position, ui::position::y, &ypos);
     std::cout << "creating text field 1" << std::endl;
     t1 = new ui::text_field(m1, 0, 0);
     xpos = 10;
     ypos = 100;
     border = 1;
     max_len = 10;
-    t1->set_va(ui::element::font, ui::ownership::shared, std_font,
-               ui::element::string, 0, &greeting,
-               ui::element::size, ui::size::max_width, &max_len,
-               ui::element::border, ui::side::all, &border,
-               ui::element::color, ui::color::foreground, &fg1,
-               ui::element::color, ui::color::background, &bg1,
-               ui::element::position, ui::position::x, &xpos,
-               ui::element::position, ui::position::y, &ypos, 0);
+    t1->set(ui::element::font, ui::ownership::shared, std_font,
+            ui::element::string, 0, &greeting,
+            ui::element::size, ui::size::max_width, &max_len,
+            ui::element::border, ui::side::all, &border,
+            ui::element::color, ui::color::foreground, &fg1,
+            ui::element::color, ui::color::background, &bg1,
+            ui::element::position, ui::position::x, &xpos,
+            ui::element::position, ui::position::y, &ypos);
     std::cout << "creating row-column 1" << std::endl;
     r1 = new ui::row_column(ctx, 10, 10);
     xpos = 520;
@@ -205,15 +205,15 @@ int main(int argc, char **argv)
     gridx = 1;
     gridy = 0;
     spacing = 10;
-    r1->set_va(ui::element::border, ui::side::all, &border,
-               ui::element::size, ui::size::columns, &gridx,
-               ui::element::size, ui::size::rows, &gridy,
-               ui::element::color, ui::color::foreground, &fg1,
-               ui::element::color, ui::color::background, &bg1,
-               ui::element::position, ui::position::x, &xpos,
-               ui::element::position, ui::position::y, &ypos,
-               ui::element::child_spacing, ui::size::width, &spacing,
-               ui::element::child_spacing, ui::size::height, &spacing, 0);
+    r1->set(ui::element::border, ui::side::all, &border,
+            ui::element::size, ui::size::columns, &gridx,
+            ui::element::size, ui::size::rows, &gridy,
+            ui::element::color, ui::color::foreground, &fg1,
+            ui::element::color, ui::color::background, &bg1,
+            ui::element::position, ui::position::x, &xpos,
+            ui::element::position, ui::position::y, &ypos,
+            ui::element::child_spacing, ui::size::width, &spacing,
+            ui::element::child_spacing, ui::size::height, &spacing);
     r1->add_callback(ui::callback::btn_down, reorient_callback, NULL);
     for (int q = 0; q < 7; ++q)
     {
@@ -225,20 +225,20 @@ int main(int argc, char **argv)
         std::string str = s.str();
         border = 1;
         wid = 100;
-        l->set_va(ui::element::font, ui::ownership::shared, std_font,
-                  ui::element::string, 0, &str,
-                  ui::element::border, ui::side::all, &border,
-                  ui::element::size, ui::size::width, &wid, 0);
+        l->set(ui::element::font, ui::ownership::shared, std_font,
+               ui::element::string, 0, &str,
+               ui::element::border, ui::side::all, &border,
+               ui::element::size, ui::size::width, &wid);
         l->add_callback(ui::callback::btn_down, print_sizes, NULL);
     }
     std::cout << "creating popup 1" << std::endl;
     pu1 = new ui::pie_menu(ctx, 200, 125);
     border = 1;
     button = ui::mouse::button0;
-    pu1->set_va(ui::element::border, ui::side::outer, &border,
-                ui::element::margin, ui::side::outer, &border,
-                ui::element::border, ui::side::inner, &border,
-                ui::element::popup, ui::popup::button, &button, 0);
+    pu1->set(ui::element::border, ui::side::outer, &border,
+             ui::element::margin, ui::side::outer, &border,
+             ui::element::border, ui::side::inner, &border,
+             ui::element::popup, ui::popup::button, &button);
     for (intptr_t q = 0; q < 7; ++q)
     {
         std::cout << "  creating child " << q << std::endl;
@@ -247,8 +247,8 @@ int main(int argc, char **argv)
 
         s << (char)('a' + q);
         std::string str = s.str();
-        pul->set_va(ui::element::font, ui::ownership::shared, tiny_font,
-                    ui::element::string, 0, &str, 0);
+        pul->set(ui::element::font, ui::ownership::shared, tiny_font,
+                 ui::element::string, 0, &str);
         pul->add_callback(ui::callback::btn_up, menu_callback, (void *)q);
         pul->add_callback(ui::callback::enter, enter_callback, (void *)q);
         pul->add_callback(ui::callback::leave, leave_callback, (void *)q);
@@ -334,10 +334,10 @@ void reorient_callback(ui::active *a, void *call, void *client)
         glm::ivec2 old_grid;
         GLuint old_orient;
 
-        r->get_va(ui::element::size, ui::size::grid, &old_grid,
-                  ui::element::order, 0, &old_orient, 0);
-        r->set_va(ui::element::size, ui::size::grid, &grid,
-                  ui::element::order, 0, &orient, 0);
+        r->get(ui::element::size, ui::size::grid, &old_grid,
+               ui::element::order, 0, &old_orient);
+        r->set(ui::element::size, ui::size::grid, &grid,
+               ui::element::order, 0, &orient);
         r->manage_children();
         grid = old_grid;
         orient = old_orient;
@@ -354,16 +354,16 @@ void print_sizes(ui::active *a, void *call, void *client)
     if (w == NULL)
         return;
 
-    w->get_va(ui::element::position, ui::position::all, &pos,
-              ui::element::size, ui::size::all, &size,
-              ui::element::border, ui::side::top, &border[0],
-              ui::element::border, ui::side::left, &border[1],
-              ui::element::border, ui::side::right, &border[2],
-              ui::element::border, ui::side::bottom, &border[3],
-              ui::element::margin, ui::side::top, &margin[0],
-              ui::element::margin, ui::side::left, &margin[1],
-              ui::element::margin, ui::side::right, &margin[2],
-              ui::element::margin, ui::side::bottom, &margin[3], 0);
+    w->get(ui::element::position, ui::position::all, &pos,
+           ui::element::size, ui::size::all, &size,
+           ui::element::border, ui::side::top, &border[0],
+           ui::element::border, ui::side::left, &border[1],
+           ui::element::border, ui::side::right, &border[2],
+           ui::element::border, ui::side::bottom, &border[3],
+           ui::element::margin, ui::side::top, &margin[0],
+           ui::element::margin, ui::side::left, &margin[1],
+           ui::element::margin, ui::side::right, &margin[2],
+           ui::element::margin, ui::side::bottom, &margin[3]);
     std::cout << "pos <" << pos.x << ", " << pos.y << ">" << std::endl;
     std::cout << "size <" << size.x << ", " << size.y << ">" << std::endl;
     std::cout << "border <" << border[0] << ", " << border[1] << ", "

--- a/text_field.cc
+++ b/text_field.cc
@@ -440,15 +440,15 @@ ui::text_field::text_field(ui::composite *c, GLuint w, GLuint h)
     this->cursor_active = false;
     this->cursor_element_count = 0;
 
-    this->parent->get_va(ui::element::attribute,
-                         ui::attribute::position,
-                         &pos_attr,
-                         ui::element::attribute,
-                         ui::attribute::color,
-                         &color_attr,
-                         ui::element::attribute,
-                         ui::attribute::texture,
-                         &texture_attr, 0);
+    this->parent->get(ui::element::attribute,
+                      ui::attribute::position,
+                      &pos_attr,
+                      ui::element::attribute,
+                      ui::attribute::color,
+                      &color_attr,
+                      ui::element::attribute,
+                      ui::attribute::texture,
+                      &texture_attr);
 
     glGenVertexArrays(1, &this->cursor_vao);
     glBindVertexArray(this->cursor_vao);

--- a/text_field.cc
+++ b/text_field.cc
@@ -1,6 +1,6 @@
 /* text_field.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 05 Aug 2018, 08:09:42 tquirk
+ *   last updated 04 Sep 2018, 06:49:22 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -48,20 +48,17 @@ int ui::text_field::get_size(GLuint t, void *v) const
     }
 }
 
-void ui::text_field::set_size(GLuint t, const void *v)
+void ui::text_field::set_size(GLuint t, GLuint v)
 {
-    switch (t)
+    if (t == ui::size::max_width)
     {
-      case ui::size::max_width:
-        this->max_length = *reinterpret_cast<const int *>(v);
+        this->max_length = v;
         this->calculate_widget_size();
         this->populate_buffers();
         this->reset_cursor();
-        break;
-      default:
-        this->label::set_size(t, v);
-        break;
     }
+    else
+        this->label::set_size(t, v);
 }
 
 int ui::text_field::get_cursor(GLuint t, void *v) const
@@ -76,20 +73,19 @@ int ui::text_field::get_cursor(GLuint t, void *v) const
     }
 }
 
-void ui::text_field::set_cursor(GLuint t, const void *v)
+void ui::text_field::set_cursor(GLuint t, GLuint v)
 {
-    GLuint val = *reinterpret_cast<const GLuint *>(v);
-
     switch (t)
     {
-      case ui::cursor::position:  this->set_cursor_pos(val);    break;
-      case ui::cursor::blink:     this->set_cursor_blink(val);  break;
+      case ui::cursor::position:  this->set_cursor_pos(v);    break;
+      case ui::cursor::blink:     this->set_cursor_blink(v);  break;
+      default:                                                return;
     }
     this->generate_string_image();
     this->reset_cursor();
 }
 
-void ui::text_field::set_font(GLuint t, const void *v)
+void ui::text_field::set_font(GLuint t, const ui::base_font *v)
 {
     this->label::set_font(t, v);
 
@@ -99,7 +95,7 @@ void ui::text_field::set_font(GLuint t, const void *v)
     this->reset_cursor();
 }
 
-void ui::text_field::set_string(GLuint t, const void *v)
+void ui::text_field::set_string(GLuint t, const std::string& v)
 {
     this->label::set_string(t, v);
     this->cursor_pos = this->str.size();
@@ -107,7 +103,7 @@ void ui::text_field::set_string(GLuint t, const void *v)
     this->reset_cursor();
 }
 
-void ui::text_field::set_image(GLuint t, const void *v)
+void ui::text_field::set_image(GLuint t, const ui::image& v)
 {
     /* Don't do anything; this doesn't make sense in this widget. */
 }
@@ -357,7 +353,7 @@ void ui::text_field::calculate_widget_size(void)
     size.y = font_max[1] + font_max[2]
         + this->border[0] + this->border[3]
         + this->margin[0] + this->margin[3] + 2;
-    this->set_size(ui::size::all, &size);
+    this->set_size(ui::size::all, size);
 }
 
 void ui::text_field::generate_cursor(void)
@@ -495,7 +491,7 @@ int ui::text_field::get(GLuint e, GLuint t, void *v) const
     }
 }
 
-void ui::text_field::set(GLuint e, GLuint t, const void *v)
+void ui::text_field::set(GLuint e, GLuint t, GLuint v)
 {
     switch (e)
     {

--- a/text_field.h
+++ b/text_field.h
@@ -1,6 +1,6 @@
 /* text_field.h                                            -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 28 Jul 2018, 08:06:33 tquirk
+ *   last updated 12 Aug 2018, 07:05:42 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -90,6 +90,9 @@ namespace ui
 
         virtual int get(GLuint, GLuint, void *) const override;
         virtual void set(GLuint, GLuint, const void *) override;
+
+        GET_VA;
+        SET_VA;
 
         virtual void draw(GLuint, const glm::mat4&) override;
     };

--- a/text_field.h
+++ b/text_field.h
@@ -1,6 +1,6 @@
 /* text_field.h                                            -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 12 Aug 2018, 07:05:42 tquirk
+ *   last updated 04 Sep 2018, 06:49:06 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -47,12 +47,13 @@ namespace ui
         bool cursor_visible, cursor_active;
 
         virtual int get_size(GLuint, void *) const override;
-        virtual void set_size(GLuint, const void *) override;
+        using ui::label::set_size;
+        virtual void set_size(GLuint, GLuint) override;
         virtual int get_cursor(GLuint, void *) const;
-        virtual void set_cursor(GLuint, const void *);
-        virtual void set_font(GLuint, const void *) override;
-        virtual void set_string(GLuint, const void *) override;
-        virtual void set_image(GLuint, const void *) final;
+        virtual void set_cursor(GLuint, GLuint);
+        virtual void set_font(GLuint, const ui::base_font *) override;
+        virtual void set_string(GLuint, const std::string&) override;
+        virtual void set_image(GLuint, const ui::image&) final;
 
         static void enter_callback(active *, void *, void *);
         static void leave_callback(active *, void *, void *);
@@ -89,7 +90,8 @@ namespace ui
         virtual ~text_field();
 
         virtual int get(GLuint, GLuint, void *) const override;
-        virtual void set(GLuint, GLuint, const void *) override;
+        using ui::label::set;
+        virtual void set(GLuint, GLuint, GLuint) override;
 
         GET_VA;
         SET_VA;

--- a/ui.h
+++ b/ui.h
@@ -1,6 +1,6 @@
 /* ui.h                                                    -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 28 Jul 2018, 08:07:48 tquirk
+ *   last updated 12 Aug 2018, 07:05:53 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -53,6 +53,8 @@ namespace ui
         ~context();
 
         virtual int get(GLuint, GLuint, void *) const override;
+
+        GET_VA;
 
         void draw(void);
     };

--- a/ui_defs.h
+++ b/ui_defs.h
@@ -1,6 +1,6 @@
 /* ui_defs.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 23 May 2018, 08:34:40 tquirk
+ *   last updated 12 Aug 2018, 07:06:45 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -70,6 +70,18 @@ namespace ui
         glm::ivec2 new_size;
     }
     resize_call_data;
+
+#define GET_VA template<typename... Args> \
+               int get(GLuint e, GLuint t, void *v, Args... args) const \
+               { \
+                   return this->get(e, t, v) + this->get(args...); \
+               };
+#define SET_VA template<typename... Args> \
+               void set(GLuint e, GLuint t, const void *v, Args... args) \
+               { \
+                   this->set(e, t, v); \
+                   this->set(args...); \
+               };
 
     namespace element
     {

--- a/ui_defs.h
+++ b/ui_defs.h
@@ -1,6 +1,6 @@
 /* ui_defs.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 12 Aug 2018, 07:06:45 tquirk
+ *   last updated 04 Sep 2018, 06:59:13 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2017  Trinity Annabelle Quirk
@@ -76,11 +76,12 @@ namespace ui
                { \
                    return this->get(e, t, v) + this->get(args...); \
                };
-#define SET_VA template<typename... Args> \
-               void set(GLuint e, GLuint t, const void *v, Args... args) \
-               { \
-                   this->set(e, t, v); \
-                   this->set(args...); \
+
+#define SET_VA template<typename A, typename... Args>                \
+               void set(GLuint e, GLuint t, A v, Args... args)       \
+               {                                                     \
+                   this->set(e, t, v);                               \
+                   this->set(args...);                               \
                };
 
     namespace element

--- a/widget.cc
+++ b/widget.cc
@@ -485,15 +485,15 @@ ui::widget::widget(ui::composite *c, GLuint w, GLuint h)
     this->parent = c;
     this->parent->add_child(this);
 
-    this->parent->get_va(ui::element::attribute,
-                         ui::attribute::position,
-                         &pos_attr,
-                         ui::element::attribute,
-                         ui::attribute::color,
-                         &color_attr,
-                         ui::element::attribute,
-                         ui::attribute::texture,
-                         &texture_attr, 0);
+    this->parent->get(ui::element::attribute,
+                      ui::attribute::position,
+                      &pos_attr,
+                      ui::element::attribute,
+                      ui::attribute::color,
+                      &color_attr,
+                      ui::element::attribute,
+                      ui::attribute::texture,
+                      &texture_attr);
 
     glGenVertexArrays(1, &this->vao);
     glBindVertexArray(this->vao);

--- a/widget.cc
+++ b/widget.cc
@@ -1,6 +1,6 @@
 /* widget.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Jul 2018, 10:52:08 tquirk
+ *   last updated 08 Sep 2018, 08:07:07 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -241,23 +241,27 @@ int ui::widget::get_position(GLuint t, void *v) const
     return ret;
 }
 
-void ui::widget::set_position(GLuint t, const void *v)
+void ui::widget::set_position(GLuint t, GLuint v)
 {
     switch (t)
     {
-      case ui::position::all:
-        this->pos = *reinterpret_cast<const glm::ivec2 *>(v);
-        break;
-      case ui::position::x:
-        this->pos.x = *reinterpret_cast<const int *>(v);
-        break;
-      case ui::position::y:
-        this->pos.y = *reinterpret_cast<const int *>(v);
-        break;
+      case ui::position::x:  this->pos.x = v;  break;
+      case ui::position::y:  this->pos.y = v;  break;
+      default:                                 return;
     }
 
     this->parent->move_child(this);
     this->recalculate_transformation_matrix();
+}
+
+void ui::widget::set_position(GLuint t, const glm::ivec2& v)
+{
+    if (t == ui::position::all)
+    {
+        this->pos = v;
+        this->parent->move_child(this);
+        this->recalculate_transformation_matrix();
+    }
 }
 
 int ui::widget::get_state(GLuint t, void *v) const
@@ -270,11 +274,11 @@ int ui::widget::get_state(GLuint t, void *v) const
     return 1;
 }
 
-void ui::widget::set_state(GLuint t, const void *v)
+void ui::widget::set_state(GLuint t, bool v)
 {
     if (t == ui::state::visible)
     {
-        this->visible = *reinterpret_cast<const bool *>(v);
+        this->visible = v;
         this->parent->move_child(this);
     }
 }
@@ -304,14 +308,12 @@ int ui::widget::get_border(GLuint t, void *v) const
     return ret;
 }
 
-void ui::widget::set_border(GLuint t, const void *v)
+void ui::widget::set_border(GLuint t, GLuint v)
 {
-    GLuint new_v = *reinterpret_cast<const GLuint *>(v);
-
-    if (t & ui::side::top)     this->border[0] = new_v;
-    if (t & ui::side::left)    this->border[1] = new_v;
-    if (t & ui::side::right)   this->border[2] = new_v;
-    if (t & ui::side::bottom)  this->border[3] = new_v;
+    if (t & ui::side::top)     this->border[0] = v;
+    if (t & ui::side::left)    this->border[1] = v;
+    if (t & ui::side::right)   this->border[2] = v;
+    if (t & ui::side::bottom)  this->border[3] = v;
 
     this->populate_buffers();
 }
@@ -341,14 +343,12 @@ int ui::widget::get_margin(GLuint t, void *v) const
     return ret;
 }
 
-void ui::widget::set_margin(GLuint t, const void *v)
+void ui::widget::set_margin(GLuint t, GLuint v)
 {
-    GLuint new_v = *reinterpret_cast<const GLuint *>(v);
-
-    if (t & ui::side::top)     this->margin[0] = new_v;
-    if (t & ui::side::left)    this->margin[1] = new_v;
-    if (t & ui::side::right)   this->margin[2] = new_v;
-    if (t & ui::side::bottom)  this->margin[3] = new_v;
+    if (t & ui::side::top)     this->margin[0] = v;
+    if (t & ui::side::left)    this->margin[1] = v;
+    if (t & ui::side::right)   this->margin[2] = v;
+    if (t & ui::side::bottom)  this->margin[3] = v;
 
     this->populate_buffers();
 }
@@ -374,18 +374,22 @@ int ui::widget::get_color(GLuint t, void *v) const
     return ret;
 }
 
-void ui::widget::set_color(GLuint t, const void *v)
+void ui::widget::set_color(GLuint t, const glm::vec4& v)
 {
-    if (t & ui::color::foreground)
-        memcpy(glm::value_ptr(this->foreground), v, sizeof(float) * 4);
-
-    if (t & ui::color::background)
-        memcpy(glm::value_ptr(this->background), v, sizeof(float) * 4);
+    if (t & ui::color::foreground)  this->foreground = v;
+    if (t & ui::color::background)  this->background = v;
 
     this->populate_buffers();
 }
 
-void ui::widget::set_size(GLuint t, const void *v)
+void ui::widget::set_size(GLuint t, GLuint v)
+{
+    this->rect::set_size(t, v);
+    this->populate_buffers();
+    this->parent->move_child(this);
+}
+
+void ui::widget::set_size(GLuint t, const glm::ivec2& v)
 {
     this->rect::set_size(t, v);
     this->populate_buffers();
@@ -541,17 +545,36 @@ int ui::widget::get(GLuint e, GLuint t, void *v) const
     return ret;
 }
 
-void ui::widget::set(GLuint e, GLuint t, const void *v)
+void ui::widget::set(GLuint e, GLuint t, GLuint v)
 {
     switch (e)
     {
-      case ui::element::position:  this->set_position(t, v);    break;
-      case ui::element::state:     this->set_state(t, v);       break;
-      case ui::element::border:    this->set_border(t, v);      break;
-      case ui::element::margin:    this->set_margin(t, v);      break;
-      case ui::element::color:     this->set_color(t, v);       break;
-      default:                     this->active::set(e, t, v);  break;
+      case ui::element::size:      this->set_size(t, v);      break;
+      case ui::element::position:  this->set_position(t, v);  break;
+      case ui::element::border:    this->set_border(t, v);    break;
+      case ui::element::margin:    this->set_margin(t, v);    break;
     }
+}
+
+void ui::widget::set(GLuint e, GLuint t, const glm::ivec2& v)
+{
+    switch (e)
+    {
+      case ui::element::size:      this->set_size(t, v);      break;
+      case ui::element::position:  this->set_position(t, v);  break;
+    }
+}
+
+void ui::widget::set(GLuint e, GLuint t, bool v)
+{
+    if (e == ui::element::state)
+        this->set_state(t, v);
+}
+
+void ui::widget::set(GLuint e, GLuint t, const glm::vec4& v)
+{
+    if (e == ui::element::color)
+        this->set_color(t, v);
 }
 
 void ui::widget::draw(GLuint trans_uniform, const glm::mat4& parent_trans)

--- a/widget.h
+++ b/widget.h
@@ -1,6 +1,6 @@
 /* widget.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 12 Aug 2018, 07:06:44 tquirk
+ *   last updated 02 Sep 2018, 07:44:35 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -75,16 +75,18 @@ namespace ui
         bool visible;
 
         int get_position(GLuint, void *) const;
-        void set_position(GLuint, const void *);
+        void set_position(GLuint, GLuint);
+        void set_position(GLuint, const glm::ivec2&);
         virtual int get_state(GLuint, void *) const;
-        virtual void set_state(GLuint, const void *);
+        virtual void set_state(GLuint, bool);
         virtual int get_border(GLuint, void *) const;
-        virtual void set_border(GLuint, const void *);
+        virtual void set_border(GLuint, GLuint);
         virtual int get_margin(GLuint, void *) const;
-        virtual void set_margin(GLuint, const void *);
+        virtual void set_margin(GLuint, GLuint);
         int get_color(GLuint, void *) const;
-        void set_color(GLuint, const void *);
-        virtual void set_size(GLuint, const void *) override;
+        void set_color(GLuint, const glm::vec4&);
+        virtual void set_size(GLuint, GLuint) override;
+        virtual void set_size(GLuint, const glm::ivec2&) override;
 
         virtual void recalculate_transformation_matrix(void);
         virtual vertex_buffer *generate_points(void);
@@ -95,7 +97,11 @@ namespace ui
         virtual ~widget();
 
         virtual int get(GLuint, GLuint, void *) const override;
-        virtual void set(GLuint, GLuint, const void *) override;
+        using ui::rect::set;
+        virtual void set(GLuint, GLuint, GLuint) override;
+        virtual void set(GLuint, GLuint, const glm::ivec2&) override;
+        virtual void set(GLuint, GLuint, bool);
+        virtual void set(GLuint, GLuint, const glm::vec4&);
 
         GET_VA;
         SET_VA;

--- a/widget.h
+++ b/widget.h
@@ -1,6 +1,6 @@
 /* widget.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 28 Jul 2018, 07:39:21 tquirk
+ *   last updated 12 Aug 2018, 07:06:44 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -96,6 +96,9 @@ namespace ui
 
         virtual int get(GLuint, GLuint, void *) const override;
         virtual void set(GLuint, GLuint, const void *) override;
+
+        GET_VA;
+        SET_VA;
 
         virtual void draw(GLuint, const glm::mat4&);
 


### PR DESCRIPTION
This will resolve issue #7, adding the ability to pass literals in as `set()` arguments.