### PR TITLE
Improve setting font elements in ui::label and descendents

### DIFF
--- a/label.cc
+++ b/label.cc
@@ -1,6 +1,6 @@
 /* label.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 04 Sep 2018, 06:48:26 tquirk
+ *   last updated 18 Nov 2018, 09:30:01 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -46,13 +46,13 @@ int ui::label::get_font(GLuint t, void *v) const
 }
 
 /* ARGSUSED */
-void ui::label::set_font(GLuint t, const ui::base_font *v)
+void ui::label::set_font(GLuint t, ui::base_font *v)
 {
     if (t == ui::ownership::shared)
         this->shared_font = true;
     else
         this->shared_font = false;
-    this->font = const_cast<ui::base_font *>(v);
+    this->font = v;
     this->generate_string_image();
 }
 
@@ -224,7 +224,7 @@ int ui::label::get(GLuint e, GLuint t, void *v) const
     }
 }
 
-void ui::label::set(GLuint e, GLuint t, const ui::base_font *v)
+void ui::label::set(GLuint e, GLuint t, ui::base_font *v)
 {
     if (e == ui::element::font)
         this->set_font(t, v);

--- a/label.h
+++ b/label.h
@@ -1,6 +1,6 @@
 /* label.h                                                 -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 04 Sep 2018, 06:45:45 tquirk
+ *   last updated 18 Nov 2018, 09:34:58 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -51,7 +51,7 @@ namespace ui
         GLuint tex;
 
         int get_font(GLuint, void *) const;
-        virtual void set_font(GLuint, const ui::base_font *);
+        virtual void set_font(GLuint, ui::base_font *);
         int get_string(GLuint, void *) const;
         virtual void set_string(GLuint, const std::string&);
         int get_image(GLuint, void *) const;
@@ -70,7 +70,11 @@ namespace ui
 
         virtual int get(GLuint, GLuint, void *) const override;
         using ui::widget::set;
-        virtual void set(GLuint, GLuint, const ui::base_font *);
+        virtual void set(GLuint, GLuint, ui::base_font *);
+        virtual void set(GLuint a, GLuint b, ui::font *c)
+            { this->set(a, b, (ui::base_font *)c); }
+        virtual void set(GLuint a, GLuint b, ui::font_set *c)
+            { this->set(a, b, (ui::base_font *)c); }
         virtual void set(GLuint, GLuint, const std::string&);
         virtual void set(GLuint, GLuint, const ui::image&);
 

--- a/test/uitest.cc
+++ b/test/uitest.cc
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
             ui::element::position, ui::position::y, 50);
     std::cout << "creating label 1" << std::endl;
     l1 = new ui::label(ctx, 0, 0);
-    l1->set(ui::element::font, ui::ownership::shared, (const ui::base_font *)std_font,
+    l1->set(ui::element::font, ui::ownership::shared, std_font,
             ui::element::string, 0, greeting,
             ui::element::color, ui::color::foreground, fg1,
             ui::element::border, ui::side::all, 1,
@@ -138,7 +138,7 @@ int main(int argc, char **argv)
             ui::element::position, ui::position::y, 175);
     std::cout << "creating password 1" << std::endl;
     pw1 = new ui::password(ctx, 0, 0);
-    pw1->set(ui::element::font, ui::ownership::shared, (const ui::base_font *)std_font,
+    pw1->set(ui::element::font, ui::ownership::shared, std_font,
              ui::element::border, ui::side::all, 1,
              ui::element::color, ui::color::foreground, fg1,
              ui::element::color, ui::color::background, bg2,
@@ -156,7 +156,7 @@ int main(int argc, char **argv)
             ui::element::child_spacing, ui::size::height, 10);
     std::cout << "creating button 2" << std::endl;
     b2 = new ui::button(m1, 0, 0);
-    b2->set(ui::element::font, ui::ownership::shared, (const ui::base_font *)std_font,
+    b2->set(ui::element::font, ui::ownership::shared, std_font,
             ui::element::color, ui::color::foreground, fg2,
             ui::element::string, 0, greeting,
             ui::element::margin, ui::side::all, 5,
@@ -165,7 +165,7 @@ int main(int argc, char **argv)
             ui::element::position, ui::position::y, 10);
     std::cout << "creating text field 1" << std::endl;
     t1 = new ui::text_field(m1, 0, 0);
-    t1->set(ui::element::font, ui::ownership::shared, (const ui::base_font *)std_font,
+    t1->set(ui::element::font, ui::ownership::shared, std_font,
             ui::element::string, 0, greeting,
             ui::element::size, ui::size::max_width, 10,
             ui::element::border, ui::side::all, 1,
@@ -192,7 +192,7 @@ int main(int argc, char **argv)
         ui::label *l = new ui::label(r1, 0, 0);
 
         s << "Label " << q << "\n" << greeting;
-        l->set(ui::element::font, ui::ownership::shared, (const ui::base_font *)std_font,
+        l->set(ui::element::font, ui::ownership::shared, std_font,
                ui::element::string, 0, s.str(),
                ui::element::border, ui::side::all, 1,
                ui::element::size, ui::size::width, 100);
@@ -211,7 +211,7 @@ int main(int argc, char **argv)
         ui::label *pul = new ui::label(pu1, 0, 0);
 
         s << (char)('a' + q);
-        pul->set(ui::element::font, ui::ownership::shared, (const ui::base_font *)tiny_font,
+        pul->set(ui::element::font, ui::ownership::shared, tiny_font,
                  ui::element::string, 0, s.str());
         pul->add_callback(ui::callback::btn_up, menu_callback, (void *)q);
         pul->add_callback(ui::callback::enter, enter_callback, (void *)q);

--- a/text_field.cc
+++ b/text_field.cc
@@ -1,6 +1,6 @@
 /* text_field.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 04 Sep 2018, 06:49:22 tquirk
+ *   last updated 18 Nov 2018, 09:30:55 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -85,7 +85,7 @@ void ui::text_field::set_cursor(GLuint t, GLuint v)
     this->reset_cursor();
 }
 
-void ui::text_field::set_font(GLuint t, const ui::base_font *v)
+void ui::text_field::set_font(GLuint t, ui::base_font *v)
 {
     this->label::set_font(t, v);
 

--- a/text_field.h
+++ b/text_field.h
@@ -1,6 +1,6 @@
 /* text_field.h                                            -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 04 Sep 2018, 06:49:06 tquirk
+ *   last updated 18 Nov 2018, 09:30:42 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -51,7 +51,7 @@ namespace ui
         virtual void set_size(GLuint, GLuint) override;
         virtual int get_cursor(GLuint, void *) const;
         virtual void set_cursor(GLuint, GLuint);
-        virtual void set_font(GLuint, const ui::base_font *) override;
+        virtual void set_font(GLuint, ui::base_font *) override;
         virtual void set_string(GLuint, const std::string&) override;
         virtual void set_image(GLuint, const ui::image&) final;
 


### PR DESCRIPTION
The fact that we've been taking all of our set() arguments as const
objects is not correct for the way that we use a font.  Instead of
casting away const at our first opportunity, we'll just get rid of
the const specifiers in all of the font-related set() methods.

Furthermore, when we pass a ui::font or ui::font_set pointer into
one of the set() methods which is expecting a ui::base_font
pointer, we get type problems.  I thought C++ was supposed to treat
pointers automatically as any of their parent classes, but that
doesn't seem to be the case.  We add wrapper methods in the
ui::label to handle the simple cast for us.

Re:  issue #62