### PR TITLE
Travis xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: cpp
-os:
-- linux
-sudo: required
-dist: trusty
+matrix:
+  include:
+    - os: linux
+      sudo: required
+      dist: trusty
+    - os: linux
+      sudo: required
+      dist: xenial
 compiler:
 - clang
 - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,6 @@ addons:
     - x11proto-randr-dev
     - xorg-dev
     - xvfb
-  artifacts:
-    paths:
-    - $PWD/test/uitest.xwd
 before_script:
 - wget https://github.com/glfw/glfw/releases/download/3.2/glfw-3.2.zip -O /tmp/glfw-3.2.zip
 - unzip /tmp/glfw-3.2.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,29 @@ matrix:
     - os: linux
       sudo: required
       dist: trusty
-      compiler:
-      - clang
-      - gcc
+      compiler: clang
+    - os: linux
+      sudo: required
+      dist: trusty
+      compiler: gcc
     - os: linux
       sudo: required
       dist: xenial
-      compiler:
-      - clang
-      - gcc
+      compiler: clang
       addons:
         apt:
           packages:
           - libglu1-mesa-dev
+          - x11proto-randr-dev
+    - os: linux
+      sudo: required
+      dist: xenial
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+          - libglu1-mesa-dev
+          - x11proto-randr-dev
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,19 @@ matrix:
     - os: linux
       sudo: required
       dist: trusty
+      compiler:
+      - clang
+      - gcc
     - os: linux
       sudo: required
       dist: xenial
-compiler:
-- clang
-- gcc
+      compiler:
+      - clang
+      - gcc
+      addons:
+        apt:
+          packages:
+          - libglu1-mesa-dev
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,20 +13,10 @@ matrix:
       sudo: required
       dist: xenial
       compiler: clang
-      addons:
-        apt:
-          packages:
-          - libglu1-mesa-dev
-          - x11proto-randr-dev
     - os: linux
       sudo: required
       dist: xenial
       compiler: gcc
-      addons:
-        apt:
-          packages:
-          - libglu1-mesa-dev
-          - x11proto-randr-dev
 addons:
   apt:
     packages:
@@ -35,12 +25,14 @@ addons:
     - gettext
     - libboost-dev
     - libgl1-mesa-dev
+    - libglu1-mesa-dev
     - libglm-dev
     - libfreetype6-dev
     - libx11-guitest-perl
     - perl-doc
     - python3-pip
     - x11-apps
+    - x11proto-randr-dev
     - xorg-dev
     - xvfb
   artifacts:

--- a/shaders/ui_fragment.3.glsl
+++ b/shaders/ui_fragment.3.glsl
@@ -1,4 +1,4 @@
-#version 330 core
+#version 130
 
 in vec4 vcolor;
 in vec2 tex_coord;

--- a/shaders/ui_vertex.3.glsl
+++ b/shaders/ui_vertex.3.glsl
@@ -1,4 +1,4 @@
-#version 330 core
+#version 130
 
 in vec2 position;
 in vec4 color;


### PR DESCRIPTION
Now that Travis CI provides Xenial Xerus images, which are way newer than the Trusty Tahr we've been building on, we should use them.

Re:  issue #64