### PR TITLE
Improve vertex buffer

### DIFF
--- a/doc/ui::vertex_buffer.md
+++ b/doc/ui::vertex_buffer.md
@@ -10,13 +10,19 @@ ui::vertex_buffer
 ```c++
 #include <widget.h>
 
-ui::vertex_buffer *b = new ui::vertex_buffer(vert_sz, elt_sz);
+ui::vertex_buffer *b = new ui::vertex_buffer();
 
 b->generate_box(upper_left, lower_right, color);
 
 b->generate_ellipse(center, radii, inner_pct, segments, color);
 
 b->generate_ellipse_divider(center, radii, inner_pct, angle, color);
+
+size_t vert_count = b->vertex_size();
+const float *verts = b->vertex_data();
+
+size_t elt_count = b->element_size();
+const GLuint *elts = b->element_data();
 ```
 
 ## DESCRIPTION ##
@@ -62,12 +68,9 @@ would correspond with `vertex[8]`, and so on.
 
 ## CONSTRUCTION ##
 
-* **vertex_buffer(GLuint _vertices_, GLuint _elements_)**
+* **vertex_buffer()**
 
-  Creates a vertex buffer with the specified number of vertices and
-  element items.  Vertex/element array sizes are static and allocated
-  at construction time, so the maximum possible number of vertices and
-  elements should be specified.
+  Creates a vertex buffer.
 
 ## METHODS ##
 
@@ -108,23 +111,27 @@ would correspond with `vertex[8]`, and so on.
   divider will be located.  0 is along the positive x-axis, and moves
   clockwise as the angle increases.
 
+* **const float *vertex_data(void)**
+
+  Return a vertex data array suitable for passing into the
+  `glBufferData` function.
+
 * **size_t vertex_size(void)**
 
   Return the size in bytes of the vertex buffer items which have been
   added via the generation methods above.  The `glBufferData` function
   requires this size directly.
 
-  This may be smaller than the total size of the internal vertex
-  array.
+* **const float *element_data(void)**
+
+  Return an element data array suitable for passing into the
+  `glBufferData` function.
 
 * **size_t element_size(void)**
 
   Return the size in bytes of the element buffer items which have been
   added via the generation methods above.  The `glBufferData` function
   requires this size directly.
-
-  This may be smaller than the total size of the internal element
-  array.
 
 ## CONSTANTS ##
 
@@ -136,15 +143,6 @@ would correspond with `vertex[8]`, and so on.
   texture map is required for some piece of the generated primitives.
 
 ## BUGS ##
-
-No range checking is performed when adding vertices and elements to
-the arrays, so if the `ui::vertex_buffer` is too small for the
-required number of items, inadvertent overwriting of other memory will
-occur, possibly resulting in a segmentation fault.
-
-The number of items contained within the `ui::vertex_buffer` is
-static.  It should be dynamic, as with other C++ STL container
-classes.
 
 The texture mapping primitive is entirely manual, and relies
 completely on the caller knowing the internal structure of the vertex

--- a/doc/ui::vertex_buffer.md
+++ b/doc/ui::vertex_buffer.md
@@ -18,11 +18,12 @@ b->generate_ellipse(center, radii, inner_pct, segments, color);
 
 b->generate_ellipse_divider(center, radii, inner_pct, angle, color);
 
-size_t vert_count = b->vertex_size();
+size_t vert_sz = b->vertex_size();
 const float *verts = b->vertex_data();
 
-size_t elt_count = b->element_size();
+size_t elt_sz = b->element_size();
 const GLuint *elts = b->element_data();
+GLuint elt_count = b->element_count();
 ```
 
 ## DESCRIPTION ##
@@ -132,6 +133,10 @@ would correspond with `vertex[8]`, and so on.
   Return the size in bytes of the element buffer items which have been
   added via the generation methods above.  The `glBufferData` function
   requires this size directly.
+
+* **GLuint element_count(void)**
+
+  Return the number of elements in the element buffer.
 
 ## CONSTANTS ##
 

--- a/pie_menu.cc
+++ b/pie_menu.cc
@@ -1,9 +1,9 @@
 /* pie_menu.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 20 Dec 2018, 08:14:37 tquirk
+ *   last updated 04 Jan 2019, 07:16:52 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2018  Trinity Annabelle Quirk
+ * Copyright (C) 2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -133,16 +133,7 @@ ui::vertex_buffer *ui::pie_menu::generate_points(void)
     glm::vec2 radius(this->dim.x / 2.0f, this->dim.y / 2.0f);
     float inner_pct = INNER_PCT, pct;
     int count = std::max(this->dim.x / 3, 15);
-
-    /* We need room for 6 sets of points - inner and outer edges, plus
-     * possible inner and outer borders (2 points each).  Each point
-     * is 8 floats - 2 xy, 4 color, 2 texture st.  We also need
-     * dividers for each sector, so that's another 4 points per
-     * divider.
-     */
-    ui::vertex_buffer *vb = new ui::vertex_buffer(
-        (count * 48) + (this->children.size() * 32),
-        (count * 18) + (this->children.size() * 6));
+    ui::vertex_buffer *vb = new ui::vertex_buffer();
 
     this->composite::parent->get(ui::element::pixel_size,
                                  ui::size::all,

--- a/text_field.cc
+++ b/text_field.cc
@@ -1,6 +1,6 @@
 /* text_field.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 04 Jan 2019, 06:59:13 tquirk
+ *   last updated 04 Jan 2019, 06:59:40 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -350,7 +350,7 @@ void ui::text_field::generate_cursor(void)
 {
     if (this->font != NULL)
     {
-        ui::vertex_buffer *vb = new ui::vertex_buffer(32, 6);
+        ui::vertex_buffer *vb = new ui::vertex_buffer();
         float h, m[2], b[2];
         glm::vec3 psz;
 

--- a/text_field.cc
+++ b/text_field.cc
@@ -1,9 +1,9 @@
 /* text_field.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 20 Dec 2018, 08:17:16 tquirk
+ *   last updated 04 Jan 2019, 06:59:13 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2018  Trinity Annabelle Quirk
+ * Copyright (C) 2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -370,11 +370,11 @@ void ui::text_field::generate_cursor(void)
         glBindVertexArray(this->cursor_vao);
         glBindBuffer(GL_ARRAY_BUFFER, this->cursor_vbo);
         glBufferData(GL_ARRAY_BUFFER,
-                     vb->vertex_size(), vb->vertex,
+                     vb->vertex_size(), vb->vertex_data(),
                      GL_DYNAMIC_DRAW);
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->cursor_ebo);
         glBufferData(GL_ELEMENT_ARRAY_BUFFER,
-                     vb->element_size(), vb->element,
+                     vb->element_size(), vb->element_data(),
                      GL_DYNAMIC_DRAW);
         delete vb;
     }

--- a/text_field.cc
+++ b/text_field.cc
@@ -1,6 +1,6 @@
 /* text_field.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 04 Jan 2019, 06:59:40 tquirk
+ *   last updated 04 Jan 2019, 08:16:10 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -366,7 +366,7 @@ void ui::text_field::generate_cursor(void)
                                    - b[1] - psz.y - psz.y),
                          this->foreground);
 
-        this->cursor_element_count = vb->element_index;
+        this->cursor_element_count = vb->element_count();
         glBindVertexArray(this->cursor_vao);
         glBindBuffer(GL_ARRAY_BUFFER, this->cursor_vbo);
         glBufferData(GL_ARRAY_BUFFER,

--- a/widget.cc
+++ b/widget.cc
@@ -1,6 +1,6 @@
 /* widget.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 04 Jan 2019, 06:48:55 tquirk
+ *   last updated 04 Jan 2019, 07:15:02 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -38,10 +38,9 @@
 
 const float ui::vertex_buffer::no_texture = -1000.0;
 
-ui::vertex_buffer::vertex_buffer(GLuint verts, GLuint elts)
+ui::vertex_buffer::vertex_buffer()
+    : vertex(), element()
 {
-    this->vertex = new float[verts];
-    this->element = new GLuint[elts];
     this->vertex_index = 0;
     this->vertex_count = 0;
     this->element_index = 0;
@@ -49,13 +48,14 @@ ui::vertex_buffer::vertex_buffer(GLuint verts, GLuint elts)
 
 ui::vertex_buffer::~vertex_buffer()
 {
-    delete[] this->element;
-    delete[] this->vertex;
 }
 
 void ui::vertex_buffer::generate_box(glm::vec2 ul, glm::vec2 lr,
                                      const glm::vec4& color)
 {
+    this->vertex.insert(this->vertex.end(), 32, 0.0f);
+    this->element.insert(this->element.end(), 6, 0);
+
     vertex[this->vertex_index] = ul.x;
     vertex[this->vertex_index + 1] = ul.y;
     memcpy(&vertex[this->vertex_index + 2],
@@ -118,6 +118,9 @@ void ui::vertex_buffer::generate_ellipse(glm::vec2 center, glm::vec2 radius,
     if (segments < 15)  segments = 15;
     if (segments > 720) segments = 720;
 
+    this->vertex.insert(this->vertex.end(), 16 * segments, 0.0f);
+    this->element.insert(this->element.end(), 6 * segments, 0);
+
     glm::vec2 inner = radius * inner_pct;
     float increment = M_PI * 2.0f / (float)segments;
     GLuint vertex_start_count = this->vertex_count;
@@ -162,6 +165,9 @@ void ui::vertex_buffer::generate_ellipse_divider(glm::vec2 center,
                                                  float pct, float angle,
                                                  const glm::vec4& color)
 {
+    this->vertex.insert(this->vertex.end(), 32, 0.0f);
+    this->element.insert(this->element.end(), 6, 0);
+
     glm::vec2 inner = radius * pct;
 
     vertex[this->vertex_index] = radius.x * cosf(angle) + center.x;
@@ -211,7 +217,7 @@ void ui::vertex_buffer::generate_ellipse_divider(glm::vec2 center,
 
 const float *ui::vertex_buffer::vertex_data(void)
 {
-    return this->vertex;
+    return this->vertex.data();
 }
 
 size_t ui::vertex_buffer::vertex_size(void)
@@ -221,7 +227,7 @@ size_t ui::vertex_buffer::vertex_size(void)
 
 const GLuint *ui::vertex_buffer::element_data(void)
 {
-    return this->element;
+    return this->element.data();
 }
 
 size_t ui::vertex_buffer::element_size(void)
@@ -380,11 +386,7 @@ void ui::widget::recalculate_transformation_matrix(void)
 
 ui::vertex_buffer *ui::widget::generate_points(void)
 {
-    /* This vertex buffer contains enough space for the toggle button
-     * as well.  TODO:  make the vertex buffer sized dynamically, so
-     * we don't need to worry about doing this.
-     */
-    ui::vertex_buffer *vb = new ui::vertex_buffer(416, 108);
+    ui::vertex_buffer *vb = new ui::vertex_buffer();
     float w = this->dim.x, h = this->dim.y, m[4], b[4];
     glm::vec3 psz;
 

--- a/widget.cc
+++ b/widget.cc
@@ -1,6 +1,6 @@
 /* widget.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 04 Jan 2019, 08:16:08 tquirk
+ *   last updated 04 Jan 2019, 08:21:30 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -43,7 +43,6 @@ ui::vertex_buffer::vertex_buffer()
 {
     this->vertex_index = 0;
     this->vertex_count = 0;
-    this->element_index = 0;
 }
 
 ui::vertex_buffer::~vertex_buffer()
@@ -53,6 +52,8 @@ ui::vertex_buffer::~vertex_buffer()
 void ui::vertex_buffer::generate_box(glm::vec2 ul, glm::vec2 lr,
                                      const glm::vec4& color)
 {
+    int elt_idx = this->element.size();
+
     this->vertex.insert(this->vertex.end(), 32, 0.0f);
     this->element.insert(this->element.end(), 6, 0);
 
@@ -86,13 +87,12 @@ void ui::vertex_buffer::generate_box(glm::vec2 ul, glm::vec2 lr,
     this->vertex_index += 32;
     this->vertex_count += 4;
 
-    element[this->element_index] = this->vertex_count - 4;
-    element[this->element_index + 1] = this->vertex_count - 2;
-    element[this->element_index + 2] = this->vertex_count - 3;
-    element[this->element_index + 3] = this->vertex_count - 2;
-    element[this->element_index + 4] = this->vertex_count - 1;
-    element[this->element_index + 5] = this->vertex_count - 3;
-    this->element_index += 6;
+    element[elt_idx] = this->vertex_count - 4;
+    element[elt_idx + 1] = this->vertex_count - 2;
+    element[elt_idx + 2] = this->vertex_count - 3;
+    element[elt_idx + 3] = this->vertex_count - 2;
+    element[elt_idx + 4] = this->vertex_count - 1;
+    element[elt_idx + 5] = this->vertex_count - 3;
 }
 
 /* We'll use a parametric function to draw our ellipse.
@@ -111,6 +111,8 @@ void ui::vertex_buffer::generate_ellipse(glm::vec2 center, glm::vec2 radius,
                                          float inner_pct, int segments,
                                          const glm::vec4& color)
 {
+    int elt_idx = this->element.size();
+
     /* Clamp inner_pct and segments to reasonable ranges */
     if (inner_pct < 0.0)  inner_pct = 0.0;
     if (inner_pct >= 1.0) inner_pct = 0.99;
@@ -145,19 +147,19 @@ void ui::vertex_buffer::generate_ellipse(glm::vec2 center, glm::vec2 radius,
         this->vertex_index += 16;
         this->vertex_count += 2;
 
-        element[this->element_index] = this->vertex_count - 2;
-        element[this->element_index + 1] = this->vertex_count - 1;
-        element[this->element_index + 2] = this->vertex_count + 1;
-        element[this->element_index + 3] = this->vertex_count - 2;
-        element[this->element_index + 4] = this->vertex_count + 1;
-        element[this->element_index + 5] = this->vertex_count;
-        this->element_index += 6;
+        element[elt_idx] = this->vertex_count - 2;
+        element[elt_idx + 1] = this->vertex_count - 1;
+        element[elt_idx + 2] = this->vertex_count + 1;
+        element[elt_idx + 3] = this->vertex_count - 2;
+        element[elt_idx + 4] = this->vertex_count + 1;
+        element[elt_idx + 5] = this->vertex_count;
+        elt_idx += 6;
     }
 
     /* Fix up the last segment */
-    element[this->element_index - 4] = vertex_start_count + 1;
-    element[this->element_index - 2] = vertex_start_count + 1;
-    element[this->element_index - 1] = vertex_start_count;
+    element[elt_idx - 4] = vertex_start_count + 1;
+    element[elt_idx - 2] = vertex_start_count + 1;
+    element[elt_idx - 1] = vertex_start_count;
 }
 
 void ui::vertex_buffer::generate_ellipse_divider(glm::vec2 center,
@@ -165,6 +167,8 @@ void ui::vertex_buffer::generate_ellipse_divider(glm::vec2 center,
                                                  float pct, float angle,
                                                  const glm::vec4& color)
 {
+    int elt_idx = this->element.size();
+
     this->vertex.insert(this->vertex.end(), 32, 0.0f);
     this->element.insert(this->element.end(), 6, 0);
 
@@ -206,13 +210,12 @@ void ui::vertex_buffer::generate_ellipse_divider(glm::vec2 center,
     this->vertex_index += 32;
     this->vertex_count += 4;
 
-    element[this->element_index] = this->vertex_count - 4;
-    element[this->element_index + 1] = this->vertex_count - 2;
-    element[this->element_index + 2] = this->vertex_count - 3;
-    element[this->element_index + 3] = this->vertex_count - 2;
-    element[this->element_index + 4] = this->vertex_count - 1;
-    element[this->element_index + 5] = this->vertex_count - 3;
-    this->element_index += 6;
+    element[elt_idx] = this->vertex_count - 4;
+    element[elt_idx + 1] = this->vertex_count - 2;
+    element[elt_idx + 2] = this->vertex_count - 3;
+    element[elt_idx + 3] = this->vertex_count - 2;
+    element[elt_idx + 4] = this->vertex_count - 1;
+    element[elt_idx + 5] = this->vertex_count - 3;
 }
 
 const float *ui::vertex_buffer::vertex_data(void)
@@ -232,12 +235,12 @@ const GLuint *ui::vertex_buffer::element_data(void)
 
 size_t ui::vertex_buffer::element_size(void)
 {
-    return sizeof(GLuint) * this->element_index;
+    return sizeof(GLuint) * this->element.size();
 }
 
 GLuint ui::vertex_buffer::element_count(void)
 {
-    return this->element_index;
+    return this->element.size();
 }
 
 int ui::widget::get_position(GLuint t, GLuint *v) const

--- a/widget.cc
+++ b/widget.cc
@@ -1,6 +1,6 @@
 /* widget.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 02 Jan 2019, 12:39:09 tquirk
+ *   last updated 04 Jan 2019, 06:48:55 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -209,9 +209,19 @@ void ui::vertex_buffer::generate_ellipse_divider(glm::vec2 center,
     this->element_index += 6;
 }
 
+const float *ui::vertex_buffer::vertex_data(void)
+{
+    return this->vertex;
+}
+
 size_t ui::vertex_buffer::vertex_size(void)
 {
     return sizeof(float) * this->vertex_index;
+}
+
+const GLuint *ui::vertex_buffer::element_data(void)
+{
+    return this->element;
 }
 
 size_t ui::vertex_buffer::element_size(void)
@@ -430,11 +440,11 @@ void ui::widget::populate_buffers(void)
     glBindVertexArray(this->vao);
     glBindBuffer(GL_ARRAY_BUFFER, this->vbo);
     glBufferData(GL_ARRAY_BUFFER,
-                 vb->vertex_size(), vb->vertex,
+                 vb->vertex_size(), vb->vertex_data(),
                  GL_DYNAMIC_DRAW);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->ebo);
     glBufferData(GL_ELEMENT_ARRAY_BUFFER,
-                 vb->element_size(), vb->element,
+                 vb->element_size(), vb->element_data(),
                  GL_DYNAMIC_DRAW);
     delete vb;
 }

--- a/widget.cc
+++ b/widget.cc
@@ -1,6 +1,6 @@
 /* widget.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 04 Jan 2019, 07:15:02 tquirk
+ *   last updated 04 Jan 2019, 08:16:08 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -235,6 +235,11 @@ size_t ui::vertex_buffer::element_size(void)
     return sizeof(GLuint) * this->element_index;
 }
 
+GLuint ui::vertex_buffer::element_count(void)
+{
+    return this->element_index;
+}
+
 int ui::widget::get_position(GLuint t, GLuint *v) const
 {
     switch (t)
@@ -438,7 +443,7 @@ void ui::widget::populate_buffers(void)
     if (vb == NULL)
         return;
 
-    this->element_count = vb->element_index;
+    this->element_count = vb->element_count();
     glBindVertexArray(this->vao);
     glBindBuffer(GL_ARRAY_BUFFER, this->vbo);
     glBufferData(GL_ARRAY_BUFFER,

--- a/widget.cc
+++ b/widget.cc
@@ -1,6 +1,6 @@
 /* widget.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 04 Jan 2019, 08:21:30 tquirk
+ *   last updated 04 Jan 2019, 08:57:09 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -41,7 +41,6 @@ const float ui::vertex_buffer::no_texture = -1000.0;
 ui::vertex_buffer::vertex_buffer()
     : vertex(), element()
 {
-    this->vertex_count = 0;
 }
 
 ui::vertex_buffer::~vertex_buffer()
@@ -52,6 +51,7 @@ void ui::vertex_buffer::generate_box(glm::vec2 ul, glm::vec2 lr,
                                      const glm::vec4& color)
 {
     int vert_idx = this->vertex.size(), elt_idx = this->element.size();
+    int vert_count = vert_idx / 8;
 
     this->vertex.insert(this->vertex.end(), 32, 0.0f);
     this->element.insert(this->element.end(), 6, 0);
@@ -79,14 +79,14 @@ void ui::vertex_buffer::generate_box(glm::vec2 ul, glm::vec2 lr,
     memcpy(&vertex[vert_idx + 26], glm::value_ptr(color), sizeof(float) * 4);
     vertex[vert_idx + 30] = ui::vertex_buffer::no_texture;
     vertex[vert_idx + 31] = ui::vertex_buffer::no_texture;
-    this->vertex_count += 4;
+    vert_count += 4;
 
-    element[elt_idx] = this->vertex_count - 4;
-    element[elt_idx + 1] = this->vertex_count - 2;
-    element[elt_idx + 2] = this->vertex_count - 3;
-    element[elt_idx + 3] = this->vertex_count - 2;
-    element[elt_idx + 4] = this->vertex_count - 1;
-    element[elt_idx + 5] = this->vertex_count - 3;
+    element[elt_idx] = vert_count - 4;
+    element[elt_idx + 1] = vert_count - 2;
+    element[elt_idx + 2] = vert_count - 3;
+    element[elt_idx + 3] = vert_count - 2;
+    element[elt_idx + 4] = vert_count - 1;
+    element[elt_idx + 5] = vert_count - 3;
 }
 
 /* We'll use a parametric function to draw our ellipse.
@@ -106,6 +106,7 @@ void ui::vertex_buffer::generate_ellipse(glm::vec2 center, glm::vec2 radius,
                                          const glm::vec4& color)
 {
     int vert_idx = this->vertex.size(), elt_idx = this->element.size();
+    int vert_count = vert_idx / 8, vertex_start_count = vert_count;
 
     /* Clamp inner_pct and segments to reasonable ranges */
     if (inner_pct < 0.0)  inner_pct = 0.0;
@@ -119,7 +120,6 @@ void ui::vertex_buffer::generate_ellipse(glm::vec2 center, glm::vec2 radius,
 
     glm::vec2 inner = radius * inner_pct;
     float increment = M_PI * 2.0f / (float)segments;
-    GLuint vertex_start_count = this->vertex_count;
 
     for (int i = 0; i < segments; ++i)
     {
@@ -139,14 +139,14 @@ void ui::vertex_buffer::generate_ellipse(glm::vec2 center, glm::vec2 radius,
         vertex[vert_idx + 14] = ui::vertex_buffer::no_texture;
         vertex[vert_idx + 15] = ui::vertex_buffer::no_texture;
         vert_idx += 16;
-        this->vertex_count += 2;
+        vert_count += 2;
 
-        element[elt_idx] = this->vertex_count - 2;
-        element[elt_idx + 1] = this->vertex_count - 1;
-        element[elt_idx + 2] = this->vertex_count + 1;
-        element[elt_idx + 3] = this->vertex_count - 2;
-        element[elt_idx + 4] = this->vertex_count + 1;
-        element[elt_idx + 5] = this->vertex_count;
+        element[elt_idx] = vert_count - 2;
+        element[elt_idx + 1] = vert_count - 1;
+        element[elt_idx + 2] = vert_count + 1;
+        element[elt_idx + 3] = vert_count - 2;
+        element[elt_idx + 4] = vert_count + 1;
+        element[elt_idx + 5] = vert_count;
         elt_idx += 6;
     }
 
@@ -162,6 +162,7 @@ void ui::vertex_buffer::generate_ellipse_divider(glm::vec2 center,
                                                  const glm::vec4& color)
 {
     int vert_idx = this->vertex.size(), elt_idx = this->element.size();
+    int vert_count = vert_idx / 8;
 
     this->vertex.insert(this->vertex.end(), 32, 0.0f);
     this->element.insert(this->element.end(), 6, 0);
@@ -197,14 +198,14 @@ void ui::vertex_buffer::generate_ellipse_divider(glm::vec2 center,
     memcpy(&vertex[vert_idx + 26], glm::value_ptr(color), sizeof(float) * 4);
     vertex[vert_idx + 30] = ui::vertex_buffer::no_texture;
     vertex[vert_idx + 31] = ui::vertex_buffer::no_texture;
-    this->vertex_count += 4;
+    vert_count += 4;
 
-    element[elt_idx] = this->vertex_count - 4;
-    element[elt_idx + 1] = this->vertex_count - 2;
-    element[elt_idx + 2] = this->vertex_count - 3;
-    element[elt_idx + 3] = this->vertex_count - 2;
-    element[elt_idx + 4] = this->vertex_count - 1;
-    element[elt_idx + 5] = this->vertex_count - 3;
+    element[elt_idx] = vert_count - 4;
+    element[elt_idx + 1] = vert_count - 2;
+    element[elt_idx + 2] = vert_count - 3;
+    element[elt_idx + 3] = vert_count - 2;
+    element[elt_idx + 4] = vert_count - 1;
+    element[elt_idx + 5] = vert_count - 3;
 }
 
 const float *ui::vertex_buffer::vertex_data(void)

--- a/widget.cc
+++ b/widget.cc
@@ -41,7 +41,6 @@ const float ui::vertex_buffer::no_texture = -1000.0;
 ui::vertex_buffer::vertex_buffer()
     : vertex(), element()
 {
-    this->vertex_index = 0;
     this->vertex_count = 0;
 }
 
@@ -52,39 +51,34 @@ ui::vertex_buffer::~vertex_buffer()
 void ui::vertex_buffer::generate_box(glm::vec2 ul, glm::vec2 lr,
                                      const glm::vec4& color)
 {
-    int elt_idx = this->element.size();
+    int vert_idx = this->vertex.size(), elt_idx = this->element.size();
 
     this->vertex.insert(this->vertex.end(), 32, 0.0f);
     this->element.insert(this->element.end(), 6, 0);
 
-    vertex[this->vertex_index] = ul.x;
-    vertex[this->vertex_index + 1] = ul.y;
-    memcpy(&vertex[this->vertex_index + 2],
-           glm::value_ptr(color), sizeof(float) * 4);
-    vertex[this->vertex_index + 6] = ui::vertex_buffer::no_texture;
-    vertex[this->vertex_index + 7] = ui::vertex_buffer::no_texture;
+    vertex[vert_idx] = ul.x;
+    vertex[vert_idx + 1] = ul.y;
+    memcpy(&vertex[vert_idx + 2], glm::value_ptr(color), sizeof(float) * 4);
+    vertex[vert_idx + 6] = ui::vertex_buffer::no_texture;
+    vertex[vert_idx + 7] = ui::vertex_buffer::no_texture;
 
-    vertex[this->vertex_index + 8] = lr.x;
-    vertex[this->vertex_index + 9] = vertex[this->vertex_index + 1];
-    memcpy(&vertex[this->vertex_index + 10],
-           glm::value_ptr(color), sizeof(float) * 4);
-    vertex[this->vertex_index + 14] = ui::vertex_buffer::no_texture;
-    vertex[this->vertex_index + 15] = ui::vertex_buffer::no_texture;
+    vertex[vert_idx + 8] = lr.x;
+    vertex[vert_idx + 9] = vertex[vert_idx + 1];
+    memcpy(&vertex[vert_idx + 10], glm::value_ptr(color), sizeof(float) * 4);
+    vertex[vert_idx + 14] = ui::vertex_buffer::no_texture;
+    vertex[vert_idx + 15] = ui::vertex_buffer::no_texture;
 
-    vertex[this->vertex_index + 16] = vertex[this->vertex_index];
-    vertex[this->vertex_index + 17] = lr.y;
-    memcpy(&vertex[this->vertex_index + 18],
-           glm::value_ptr(color), sizeof(float) * 4);
-    vertex[this->vertex_index + 22] = ui::vertex_buffer::no_texture;
-    vertex[this->vertex_index + 23] = ui::vertex_buffer::no_texture;
+    vertex[vert_idx + 16] = vertex[vert_idx];
+    vertex[vert_idx + 17] = lr.y;
+    memcpy(&vertex[vert_idx + 18], glm::value_ptr(color), sizeof(float) * 4);
+    vertex[vert_idx + 22] = ui::vertex_buffer::no_texture;
+    vertex[vert_idx + 23] = ui::vertex_buffer::no_texture;
 
-    vertex[this->vertex_index + 24] = vertex[this->vertex_index + 8];
-    vertex[this->vertex_index + 25] = vertex[this->vertex_index + 17];
-    memcpy(&vertex[this->vertex_index + 26],
-           glm::value_ptr(color), sizeof(float) * 4);
-    vertex[this->vertex_index + 30] = ui::vertex_buffer::no_texture;
-    vertex[this->vertex_index + 31] = ui::vertex_buffer::no_texture;
-    this->vertex_index += 32;
+    vertex[vert_idx + 24] = vertex[vert_idx + 8];
+    vertex[vert_idx + 25] = vertex[vert_idx + 17];
+    memcpy(&vertex[vert_idx + 26], glm::value_ptr(color), sizeof(float) * 4);
+    vertex[vert_idx + 30] = ui::vertex_buffer::no_texture;
+    vertex[vert_idx + 31] = ui::vertex_buffer::no_texture;
     this->vertex_count += 4;
 
     element[elt_idx] = this->vertex_count - 4;
@@ -111,7 +105,7 @@ void ui::vertex_buffer::generate_ellipse(glm::vec2 center, glm::vec2 radius,
                                          float inner_pct, int segments,
                                          const glm::vec4& color)
 {
-    int elt_idx = this->element.size();
+    int vert_idx = this->vertex.size(), elt_idx = this->element.size();
 
     /* Clamp inner_pct and segments to reasonable ranges */
     if (inner_pct < 0.0)  inner_pct = 0.0;
@@ -131,20 +125,20 @@ void ui::vertex_buffer::generate_ellipse(glm::vec2 center, glm::vec2 radius,
     {
         float angle = increment * i;
 
-        vertex[this->vertex_index] = radius.x * cosf(angle) + center.x;
-        vertex[this->vertex_index + 1] = radius.y * sinf(angle) + center.y;
-        memcpy(&vertex[this->vertex_index + 2],
+        vertex[vert_idx] = radius.x * cosf(angle) + center.x;
+        vertex[vert_idx + 1] = radius.y * sinf(angle) + center.y;
+        memcpy(&vertex[vert_idx + 2],
                glm::value_ptr(color), sizeof(float) * 4);
-        vertex[this->vertex_index + 6] = ui::vertex_buffer::no_texture;
-        vertex[this->vertex_index + 7] = ui::vertex_buffer::no_texture;
+        vertex[vert_idx + 6] = ui::vertex_buffer::no_texture;
+        vertex[vert_idx + 7] = ui::vertex_buffer::no_texture;
 
-        vertex[this->vertex_index + 8] = inner.x * cosf(angle) + center.x;
-        vertex[this->vertex_index + 9] = inner.y * sinf(angle) + center.y;
-        memcpy(&vertex[this->vertex_index + 10],
+        vertex[vert_idx + 8] = inner.x * cosf(angle) + center.x;
+        vertex[vert_idx + 9] = inner.y * sinf(angle) + center.y;
+        memcpy(&vertex[vert_idx + 10],
                glm::value_ptr(color), sizeof(float) * 4);
-        vertex[this->vertex_index + 14] = ui::vertex_buffer::no_texture;
-        vertex[this->vertex_index + 15] = ui::vertex_buffer::no_texture;
-        this->vertex_index += 16;
+        vertex[vert_idx + 14] = ui::vertex_buffer::no_texture;
+        vertex[vert_idx + 15] = ui::vertex_buffer::no_texture;
+        vert_idx += 16;
         this->vertex_count += 2;
 
         element[elt_idx] = this->vertex_count - 2;
@@ -167,26 +161,24 @@ void ui::vertex_buffer::generate_ellipse_divider(glm::vec2 center,
                                                  float pct, float angle,
                                                  const glm::vec4& color)
 {
-    int elt_idx = this->element.size();
+    int vert_idx = this->vertex.size(), elt_idx = this->element.size();
 
     this->vertex.insert(this->vertex.end(), 32, 0.0f);
     this->element.insert(this->element.end(), 6, 0);
 
     glm::vec2 inner = radius * pct;
 
-    vertex[this->vertex_index] = radius.x * cosf(angle) + center.x;
-    vertex[this->vertex_index + 1] = radius.y * sinf(angle) + center.y;
-    memcpy(&vertex[this->vertex_index + 2],
-           glm::value_ptr(color), sizeof(float) * 4);
-    vertex[this->vertex_index + 6] = ui::vertex_buffer::no_texture;
-    vertex[this->vertex_index + 7] = ui::vertex_buffer::no_texture;
+    vertex[vert_idx] = radius.x * cosf(angle) + center.x;
+    vertex[vert_idx + 1] = radius.y * sinf(angle) + center.y;
+    memcpy(&vertex[vert_idx + 2], glm::value_ptr(color), sizeof(float) * 4);
+    vertex[vert_idx + 6] = ui::vertex_buffer::no_texture;
+    vertex[vert_idx + 7] = ui::vertex_buffer::no_texture;
 
-    vertex[this->vertex_index + 8] = inner.x * cosf(angle) + center.x;
-    vertex[this->vertex_index + 9] = inner.y * sinf(angle) + center.y;
-    memcpy(&vertex[this->vertex_index + 10],
-           glm::value_ptr(color), sizeof(float) * 4);
-    vertex[this->vertex_index + 14] = ui::vertex_buffer::no_texture;
-    vertex[this->vertex_index + 15] = ui::vertex_buffer::no_texture;
+    vertex[vert_idx + 8] = inner.x * cosf(angle) + center.x;
+    vertex[vert_idx + 9] = inner.y * sinf(angle) + center.y;
+    memcpy(&vertex[vert_idx + 10], glm::value_ptr(color), sizeof(float) * 4);
+    vertex[vert_idx + 14] = ui::vertex_buffer::no_texture;
+    vertex[vert_idx + 15] = ui::vertex_buffer::no_texture;
 
     /* Make the dividers one degree wide.  There's probably a nice way
      * to do this so the edges will be parallel, but these don't look
@@ -194,20 +186,17 @@ void ui::vertex_buffer::generate_ellipse_divider(glm::vec2 center,
      */
     angle += M_PI * 2.0f / 360;
 
-    vertex[this->vertex_index + 16] = radius.x * cosf(angle) + center.x;
-    vertex[this->vertex_index + 17] = radius.y * sinf(angle) + center.y;
-    memcpy(&vertex[this->vertex_index + 18],
-           glm::value_ptr(color), sizeof(float) * 4);
-    vertex[this->vertex_index + 22] = ui::vertex_buffer::no_texture;
-    vertex[this->vertex_index + 23] = ui::vertex_buffer::no_texture;
+    vertex[vert_idx + 16] = radius.x * cosf(angle) + center.x;
+    vertex[vert_idx + 17] = radius.y * sinf(angle) + center.y;
+    memcpy(&vertex[vert_idx + 18], glm::value_ptr(color), sizeof(float) * 4);
+    vertex[vert_idx + 22] = ui::vertex_buffer::no_texture;
+    vertex[vert_idx + 23] = ui::vertex_buffer::no_texture;
 
-    vertex[this->vertex_index + 24] = inner.x * cosf(angle) + center.x;
-    vertex[this->vertex_index + 25] = inner.y * sinf(angle) + center.y;
-    memcpy(&vertex[this->vertex_index + 26],
-           glm::value_ptr(color), sizeof(float) * 4);
-    vertex[this->vertex_index + 30] = ui::vertex_buffer::no_texture;
-    vertex[this->vertex_index + 31] = ui::vertex_buffer::no_texture;
-    this->vertex_index += 32;
+    vertex[vert_idx + 24] = inner.x * cosf(angle) + center.x;
+    vertex[vert_idx + 25] = inner.y * sinf(angle) + center.y;
+    memcpy(&vertex[vert_idx + 26], glm::value_ptr(color), sizeof(float) * 4);
+    vertex[vert_idx + 30] = ui::vertex_buffer::no_texture;
+    vertex[vert_idx + 31] = ui::vertex_buffer::no_texture;
     this->vertex_count += 4;
 
     element[elt_idx] = this->vertex_count - 4;
@@ -225,7 +214,7 @@ const float *ui::vertex_buffer::vertex_data(void)
 
 size_t ui::vertex_buffer::vertex_size(void)
 {
-    return sizeof(float) * this->vertex_index;
+    return sizeof(float) * this->vertex.size();
 }
 
 const GLuint *ui::vertex_buffer::element_data(void)

--- a/widget.h
+++ b/widget.h
@@ -1,6 +1,6 @@
 /* widget.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 04 Jan 2019, 08:14:07 tquirk
+ *   last updated 04 Jan 2019, 08:57:23 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -50,7 +50,6 @@ namespace ui
 
         std::vector<float> vertex;
         std::vector<GLuint> element;
-        GLuint vertex_count;
 
         vertex_buffer();
         ~vertex_buffer();

--- a/widget.h
+++ b/widget.h
@@ -50,7 +50,7 @@ namespace ui
 
         std::vector<float> vertex;
         std::vector<GLuint> element;
-        GLuint vertex_index, vertex_count;
+        GLuint vertex_count;
 
         vertex_buffer();
         ~vertex_buffer();

--- a/widget.h
+++ b/widget.h
@@ -50,7 +50,7 @@ namespace ui
 
         std::vector<float> vertex;
         std::vector<GLuint> element;
-        GLuint vertex_index, vertex_count, element_index;
+        GLuint vertex_index, vertex_count;
 
         vertex_buffer();
         ~vertex_buffer();

--- a/widget.h
+++ b/widget.h
@@ -1,6 +1,6 @@
 /* widget.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 04 Jan 2019, 06:58:12 tquirk
+ *   last updated 04 Jan 2019, 08:14:07 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -65,6 +65,7 @@ namespace ui
         size_t vertex_size(void);
         const GLuint *element_data(void);
         size_t element_size(void);
+        GLuint element_count(void);
     };
 
     class widget : public virtual active

--- a/widget.h
+++ b/widget.h
@@ -1,6 +1,6 @@
 /* widget.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 20 Dec 2018, 08:08:17 tquirk
+ *   last updated 04 Jan 2019, 06:47:40 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2018  Trinity Annabelle Quirk
@@ -59,7 +59,9 @@ namespace ui
         void generate_ellipse_divider(glm::vec2, glm::vec2, float, float,
                                       const glm::vec4&);
 
+        const float *vertex_data(void);
         size_t vertex_size(void);
+        const GLuint *element_data(void);
         size_t element_size(void);
     };
 

--- a/widget.h
+++ b/widget.h
@@ -1,9 +1,9 @@
 /* widget.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 04 Jan 2019, 06:47:40 tquirk
+ *   last updated 04 Jan 2019, 06:58:12 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2018  Trinity Annabelle Quirk
+ * Copyright (C) 2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -31,6 +31,8 @@
 #ifndef __INC_CUDDLY_WIDGET_H__
 #define __INC_CUDDLY_WIDGET_H__
 
+#include <vector>
+
 #include <glm/vec4.hpp>
 #include <glm/mat4x4.hpp>
 
@@ -46,11 +48,11 @@ namespace ui
     {
         const static float no_texture;
 
-        float *vertex;
-        GLuint *element;
+        std::vector<float> vertex;
+        std::vector<GLuint> element;
         GLuint vertex_index, vertex_count, element_index;
 
-        vertex_buffer(GLuint verts, GLuint elts);
+        vertex_buffer();
         ~vertex_buffer();
 
         void generate_box(glm::vec2, glm::vec2, const glm::vec4&);


### PR DESCRIPTION
This resolves issue #71 and then some.  The `ui::vertex_buffer` was a bit of a hacked-together mess, and now it's a lot cleaner.