### PR TITLE
Eliminate vector arguments from font max_cell_size

### DIFF
--- a/font.cc
+++ b/font.cc
@@ -1,6 +1,6 @@
 /* font.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 27 Aug 2019, 07:01:14 tquirk
+ *   last updated 31 Aug 2019, 08:31:21 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -409,11 +409,17 @@ ui::base_font::~base_font()
 {
 }
 
-void ui::base_font::max_cell_size(std::vector<int>& v)
+void ui::base_font::max_cell_size(int& width, int& height)
 {
-    v[0] = this->bbox_w;
-    v[1] = this->bbox_a;
-    v[2] = this->bbox_d;
+    width = this->bbox_w;
+    height = this->bbox_a + this->bbox_d;
+}
+
+void ui::base_font::max_cell_size(int& width, int& asc, int& desc)
+{
+    width = this->bbox_w;
+    asc = this->bbox_a;
+    desc = this->bbox_d;
 }
 
 /* This gets a little complicated, because a glyph which has no

--- a/font.h
+++ b/font.h
@@ -1,9 +1,9 @@
 /* font.h                                                  -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 05 Aug 2018, 07:46:58 tquirk
+ *   last updated 31 Aug 2019, 08:24:57 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2018  Trinity Annabelle Quirk
+ * Copyright (C) 2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -124,7 +124,8 @@ namespace ui
         explicit base_font(std::string&);
         virtual ~base_font();
 
-        void max_cell_size(std::vector<int>&);
+        void max_cell_size(int&, int&);
+        void max_cell_size(int&, int&, int&);
 
         virtual struct glyph& operator[](FT_ULong) = 0;
 

--- a/text_field.cc
+++ b/text_field.cc
@@ -1,6 +1,6 @@
 /* text_field.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 05 Aug 2019, 08:39:14 tquirk
+ *   last updated 31 Aug 2019, 08:29:59 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -420,15 +420,14 @@ void ui::text_field::generate_string_image(void)
 
 void ui::text_field::calculate_widget_size(void)
 {
-    std::vector<int> font_max = {0, 0, 0};
+    int max_width, max_height;
     glm::ivec2 size;
 
-    this->font->max_cell_size(font_max);
-    font_max[0] *= this->max_length;
-    size.x = font_max[0]
+    this->font->max_cell_size(max_width, max_height);
+    size.x = (max_width + this->max_length)
         + this->border[1] + this->border[2]
         + this->margin[1] + this->margin[2] + 2;
-    size.y = font_max[1] + font_max[2]
+    size.y = max_height
         + this->border[0] + this->border[3]
         + this->margin[0] + this->margin[3] + 2;
     this->set_size(ui::size::all, size);
@@ -478,23 +477,23 @@ void ui::text_field::generate_cursor(void)
 ui::vertex_buffer *ui::text_field::generate_points(void)
 {
     ui::vertex_buffer *vb = this->label::generate_points();
-    std::vector<int> font_max = {0, 0, 0};
+    int max_width, max_asc, max_desc;
     GLuint w, a, d;
     float ph;
 
     if (this->img.data == NULL)
         return vb;
 
-    this->font->max_cell_size(font_max);
+    this->font->max_cell_size(max_width, max_asc, max_desc);
     this->get_string_size(this->str, w, a, d);
 
     ph = 1.0f / (float)this->img.height;
 
     vb->vertex[7] = 1.0f + ((this->margin[0] + this->border[0] + 1
-                             + font_max[1] - a) * ph);
+                             + max_asc - a) * ph);
     vb->vertex[15] = vb->vertex[7];
     vb->vertex[23] = 0.0f - ((this->margin[3] + this->border[3] + 1
-                              + font_max[2] - d) * ph);
+                              + max_desc - d) * ph);
     vb->vertex[31] = vb->vertex[23];
 
     return vb;


### PR DESCRIPTION
Our get_string_size used to use a std::vector<int> to return its
sizes, but we realized that was overly complicated, and led to
magical constants in using the elements of the vector.  The
max_cell_size method has the same problem, so we'll make two
methods which provide either width/height or
width/ascender/descender, to mirror the get_string_size methods.

The only caller of this method is the ui::text_box, so we only have
to fix the callers in a couple small places. Our goal of making the
calling code clearer is achieved by this change.