### PR TITLE
Tab traversal

### DIFF
--- a/active.cc
+++ b/active.cc
@@ -1,9 +1,9 @@
 /* active.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 13 Nov 2017, 07:15:08 tquirk
+ *   last updated 25 Jan 2019, 22:07:36 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2016  Trinity Annabelle Quirk
+ * Copyright (C) 2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -45,13 +45,14 @@ std::list<ui::cb_list_elem>& ui::active::which_cb_list(GLuint which)
       case ui::callback::key_down:  return this->key_down_cb;
       case ui::callback::key_up:    return this->key_up_cb;
       case ui::callback::resize:    return this->resize_cb;
+      case ui::callback::focus:     return this->focus_cb;
     }
 }
 
 ui::active::active(GLuint w, GLuint h)
     : ui::rect(w, h),
       enter_cb(), leave_cb(), motion_cb(), btn_down_cb(), btn_up_cb(),
-      key_down_cb(), key_up_cb(), resize_cb()
+      key_down_cb(), key_up_cb(), resize_cb(), focus_cb()
 {
     this->timeout = ui::zero_time;
     this->timeout_func = NULL;

--- a/active.h
+++ b/active.h
@@ -1,9 +1,9 @@
 /* active.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Nov 2016, 08:16:26 tquirk
+ *   last updated 25 Jan 2019, 22:06:50 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2016  Trinity Annabelle Quirk
+ * Copyright (C) 2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -73,7 +73,7 @@ namespace ui
         std::list<cb_list_elem> enter_cb, leave_cb, motion_cb;
         std::list<cb_list_elem> btn_down_cb, btn_up_cb;
         std::list<cb_list_elem> key_down_cb, key_up_cb;
-        std::list<cb_list_elem> resize_cb;
+        std::list<cb_list_elem> resize_cb, focus_cb;
         to_point timeout;
         to_fptr timeout_func;
         void *timeout_arg;

--- a/armable.cc
+++ b/armable.cc
@@ -1,6 +1,6 @@
 /* armable.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 02 Nov 2019, 07:11:51 tquirk
+ *   last updated 03 Nov 2019, 16:20:31 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -131,12 +131,38 @@ void ui::armable::mouse_up_callback(ui::active *a, void *call, void *client)
     ui::armable *b = dynamic_cast<ui::armable *>(a);
 
     if (b != NULL)
-    {
         b->disarm();
-        if (b->parent != NULL)
-            b->parent->set(ui::element::child,
-                           ui::child::focused,
-                           (ui::widget *)NULL);
+}
+
+void ui::armable::key_down_callback(ui::active *a, void *call, void *client)
+{
+    ui::armable *b = dynamic_cast<ui::armable *>(a);
+
+    if (b != NULL)
+    {
+        ui::key_call_data *kcd = (ui::key_call_data *)call;
+        if (kcd->key == ui::key::space || kcd->character == ' ')
+        {
+            ui::btn_call_data bcd
+                = {kcd->location, ui::mouse::button0, ui::mouse::down, 0};
+            b->call_callbacks(ui::callback::btn_down, &bcd);
+        }
+    }
+}
+
+void ui::armable::key_up_callback(ui::active *a, void *call, void *client)
+{
+    ui::armable *b = dynamic_cast<ui::armable *>(a);
+
+    if (b != NULL)
+    {
+        ui::key_call_data *kcd = (ui::key_call_data *)call;
+        if (kcd->key == ui::key::space || kcd->character == ' ')
+        {
+            ui::btn_call_data bcd
+                = {kcd->location, ui::mouse::button0, ui::mouse::up, 0};
+            b->call_callbacks(ui::callback::btn_up, &bcd);
+        }
     }
 }
 
@@ -154,6 +180,12 @@ void ui::armable::init(ui::composite *c)
                        NULL);
     this->add_callback(ui::callback::btn_up,
                        ui::armable::mouse_up_callback,
+                       NULL);
+    this->add_callback(ui::callback::key_down,
+                       ui::armable::key_down_callback,
+                       NULL);
+    this->add_callback(ui::callback::key_up,
+                       ui::armable::key_up_callback,
                        NULL);
 }
 

--- a/armable.cc
+++ b/armable.cc
@@ -1,9 +1,9 @@
 /* armable.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 27 Dec 2018, 08:54:00 tquirk
+ *   last updated 29 Oct 2019, 05:33:45 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2018  Trinity Annabelle Quirk
+ * Copyright (C) 2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -66,41 +66,57 @@ int ui::armable::get_arm_state(bool *v) const
     return 0;
 }
 
-/* ARGSUSED */
-void ui::armable::activate(ui::active *a, void *call, void *client)
+void ui::armable::activate(void)
 {
-    ui::armable *b = dynamic_cast<ui::armable *>(a);
-
-    if (b != NULL)
-        b->set(ui::element::state, ui::state::active, true);
+    this->set(ui::element::state, ui::state::active, true);
 }
 
-/* ARGSUSED */
-void ui::armable::deactivate(ui::active *a, void *call, void *client)
+void ui::armable::deactivate(void)
 {
-    ui::armable *b = dynamic_cast<ui::armable *>(a);
-
-    if (b != NULL)
-        b->set(ui::element::state, ui::state::active, false,
-               ui::element::state, ui::state::armed, false);
+    this->set(ui::element::state, ui::state::active, false,
+              ui::element::state, ui::state::armed, false);
 }
 
-/* ARGSUSED */
-void ui::armable::arm(ui::active *a, void *call, void *client)
+void ui::armable::arm(void)
 {
-    ui::armable *b = dynamic_cast<ui::armable *>(a);
-
-    if (b != NULL)
-        b->set(ui::element::state, ui::state::armed, true);
+    this->set(ui::element::state, ui::state::armed, true);
 }
 
-/* ARGSUSED */
-void ui::armable::disarm(ui::active *a, void *call, void *client)
+void ui::armable::disarm(void)
+{
+    this->set(ui::element::state, ui::state::armed, false);
+}
+
+void ui::armable::enter_callback(ui::active *a, void *call, void *client)
 {
     ui::armable *b = dynamic_cast<ui::armable *>(a);
 
     if (b != NULL)
-        b->set(ui::element::state, ui::state::armed, false);
+        b->activate();
+}
+
+void ui::armable::leave_callback(ui::active *a, void *call, void *client)
+{
+    ui::armable *b = dynamic_cast<ui::armable *>(a);
+
+    if (b != NULL)
+        b->deactivate();
+}
+
+void ui::armable::mouse_down_callback(ui::active *a, void *call, void *client)
+{
+    ui::armable *b = dynamic_cast<ui::armable *>(a);
+
+    if (b != NULL)
+        b->arm();
+}
+
+void ui::armable::mouse_up_callback(ui::active *a, void *call, void *client)
+{
+    ui::armable *b = dynamic_cast<ui::armable *>(a);
+
+    if (b != NULL)
+        b->disarm();
 }
 
 void ui::armable::init(ui::composite *c)
@@ -108,10 +124,14 @@ void ui::armable::init(ui::composite *c)
     this->activated = false;
     this->armed = false;
 
-    this->add_callback(ui::callback::enter,     ui::armable::activate, NULL);
-    this->add_callback(ui::callback::leave,     ui::armable::deactivate, NULL);
-    this->add_callback(ui::callback::btn_down,  ui::armable::arm, NULL);
-    this->add_callback(ui::callback::btn_up,    ui::armable::disarm, NULL);
+    this->add_callback(ui::callback::enter, ui::armable::enter_callback, NULL);
+    this->add_callback(ui::callback::leave, ui::armable::leave_callback, NULL);
+    this->add_callback(ui::callback::btn_down,
+                       ui::armable::mouse_down_callback,
+                       NULL);
+    this->add_callback(ui::callback::btn_up,
+                       ui::armable::mouse_up_callback,
+                       NULL);
 }
 
 ui::armable::armable(ui::composite *c)

--- a/armable.h
+++ b/armable.h
@@ -1,6 +1,6 @@
 /* armable.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Oct 2019, 05:46:10 tquirk
+ *   last updated 03 Nov 2019, 15:57:55 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -62,6 +62,8 @@ namespace ui
         static void focus_callback(active *, void *, void *);
         static void mouse_down_callback(active *, void *, void *);
         static void mouse_up_callback(active *, void *, void *);
+        static void key_down_callback(active *, void *, void *);
+        static void key_up_callback(active *, void *, void *);
 
         void init(composite *);
 

--- a/armable.h
+++ b/armable.h
@@ -1,6 +1,6 @@
 /* armable.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Oct 2019, 05:29:26 tquirk
+ *   last updated 29 Oct 2019, 05:46:10 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -42,6 +42,7 @@ namespace ui
     {
       protected:
         bool activated, armed;
+        int activations;
 
         virtual int get_state(GLuint, bool *) const override;
         virtual void set_state(GLuint, bool) override;
@@ -58,6 +59,7 @@ namespace ui
 
         static void enter_callback(active *, void *, void *);
         static void leave_callback(active *, void *, void *);
+        static void focus_callback(active *, void *, void *);
         static void mouse_down_callback(active *, void *, void *);
         static void mouse_up_callback(active *, void *, void *);
 

--- a/armable.h
+++ b/armable.h
@@ -1,9 +1,9 @@
 /* armable.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 26 Dec 2018, 22:38:21 tquirk
+ *   last updated 29 Oct 2019, 05:29:26 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2018  Trinity Annabelle Quirk
+ * Copyright (C) 2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -51,10 +51,15 @@ namespace ui
         int get_arm_state(bool *) const;
         virtual void set_arm_state(bool) = 0;
 
-        static void activate(active *, void *, void *);
-        static void deactivate(active *, void *, void *);
-        static void arm(active *, void *, void *);
-        static void disarm(active *, void *, void *);
+        void activate(void);
+        void deactivate(void);
+        void arm(void);
+        void disarm(void);
+
+        static void enter_callback(active *, void *, void *);
+        static void leave_callback(active *, void *, void *);
+        static void mouse_down_callback(active *, void *, void *);
+        static void mouse_up_callback(active *, void *, void *);
 
         void init(composite *);
 

--- a/composite.cc
+++ b/composite.cc
@@ -1,6 +1,6 @@
 /* composite.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 03 Nov 2019, 10:07:40 tquirk
+ *   last updated 03 Nov 2019, 15:25:43 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -282,7 +282,8 @@ void ui::composite::focus_next_child(void)
 {
     std::list<widget *>::iterator new_focus = this->focused;
 
-    if (++new_focus == this->children.end())
+    if (this->focused == this->children.end()
+        || ++new_focus == this->children.end())
         new_focus = this->children.begin();
     this->focus_child(new_focus);
 }
@@ -509,18 +510,26 @@ void ui::composite::key_callback(ui::key_call_data& call_data)
     GLuint which = (call_data.state == ui::key::up
                     ? ui::callback::key_up
                     : ui::callback::key_down);
+    ui::composite *c = NULL;
+
+    if (this->focused != this->children.end())
+        c = dynamic_cast<ui::composite *>(*this->focused);
 
     if (call_data.key == ui::key::tab && call_data.state == ui::key::down)
     {
-        if (call_data.mods & ui::key_mod::shift)
-            this->focus_previous_child();
+        if (c != NULL)
+            c->key_callback(call_data);
         else
-            this->focus_next_child();
+        {
+            if (call_data.mods & ui::key_mod::shift)
+                this->focus_previous_child();
+            else
+                this->focus_next_child();
+        }
     }
     else if (this->focused != this->children.end())
     {
         glm::ivec2 obj;
-        ui::composite *c = dynamic_cast<ui::composite *>(*this->focused);
 
         (*this->focused)->get(ui::element::position, ui::position::all, &obj);
         call_data.location -= obj;

--- a/composite.cc
+++ b/composite.cc
@@ -1,6 +1,6 @@
 /* composite.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 03 Nov 2019, 09:05:39 tquirk
+ *   last updated 03 Nov 2019, 09:52:36 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -97,22 +97,11 @@ void ui::composite::set_focused_child(ui::widget *w)
         || (w == NULL && this->focused == this->children.end()))
         return;
 
-    ui::focus_call_data fcd;
-    if (this->focused != this->children.end())
-    {
-        fcd.focus = false;
-        (*this->focused)->call_callbacks(ui::callback::focus, &fcd);
-    }
-    fcd.focus = true;
-    this->focused = std::find(this->children.begin(),
-                              this->children.end(),
-                              w);
-    if (this->focused != this->children.end())
-        (*this->focused)->call_callbacks(ui::callback::focus, &fcd);
-    else if (this->parent != NULL)
-        this->parent->set(ui::element::child,
-                          ui::child::focused,
-                          (ui::widget *)NULL);
+    std::list<widget *>::iterator new_focus
+        = std::find(this->children.begin(), this->children.end(), w);
+    this->focus_child(new_focus);
+    if (this->parent != NULL && w == NULL)
+        this->parent->set(ui::element::child, ui::child::focused, w);
 }
 
 void ui::composite::set_size(GLuint d, GLuint v)
@@ -267,6 +256,26 @@ void ui::composite::child_motion(ui::widget *w, GLuint type, glm::ivec2& pos)
         c->mouse_pos_callback(call_data.location);
     else
         w->call_callbacks(type, &call_data);
+}
+
+void ui::composite::focus_child(std::list<widget *>::iterator new_focus)
+{
+    if (new_focus != this->focused)
+    {
+        ui::focus_call_data fcd;
+
+        if (this->focused != this->children.end())
+        {
+            fcd.focus = false;
+            (*this->focused)->call_callbacks(ui::callback::focus, &fcd);
+        }
+        this->focused = new_focus;
+        if (this->focused != this->children.end())
+        {
+            fcd.focus = true;
+            (*this->focused)->call_callbacks(ui::callback::focus, &fcd);
+        }
+    }
 }
 
 void ui::composite::focus_callback(ui::active *a, void *call, void *client)

--- a/composite.cc
+++ b/composite.cc
@@ -1,6 +1,6 @@
 /* composite.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 03 Nov 2019, 09:52:36 tquirk
+ *   last updated 03 Nov 2019, 10:07:40 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -278,6 +278,25 @@ void ui::composite::focus_child(std::list<widget *>::iterator new_focus)
     }
 }
 
+void ui::composite::focus_next_child(void)
+{
+    std::list<widget *>::iterator new_focus = this->focused;
+
+    if (++new_focus == this->children.end())
+        new_focus = this->children.begin();
+    this->focus_child(new_focus);
+}
+
+void ui::composite::focus_previous_child(void)
+{
+    std::list<widget *>::iterator new_focus = this->focused;
+
+    if (new_focus == this->children.begin())
+        new_focus = this->children.end();
+    --new_focus;
+    this->focus_child(new_focus);
+}
+
 void ui::composite::focus_callback(ui::active *a, void *call, void *client)
 {
     ui::composite *c = dynamic_cast<ui::composite *>(a);
@@ -491,7 +510,14 @@ void ui::composite::key_callback(ui::key_call_data& call_data)
                     ? ui::callback::key_up
                     : ui::callback::key_down);
 
-    if (this->focused != this->children.end())
+    if (call_data.key == ui::key::tab && call_data.state == ui::key::down)
+    {
+        if (call_data.mods & ui::key_mod::shift)
+            this->focus_previous_child();
+        else
+            this->focus_next_child();
+    }
+    else if (this->focused != this->children.end())
     {
         glm::ivec2 obj;
         ui::composite *c = dynamic_cast<ui::composite *>(*this->focused);

--- a/composite.cc
+++ b/composite.cc
@@ -1,6 +1,6 @@
 /* composite.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Oct 2019, 08:58:22 tquirk
+ *   last updated 02 Nov 2019, 07:09:24 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -103,8 +103,12 @@ void ui::composite::set_focused_child(ui::widget *w)
         }
         fcd.focus = true;
         this->focused = w;
-        if (w != NULL)
+        if (this->focused != NULL)
             this->focused->call_callbacks(ui::callback::focus, &fcd);
+        else if (this->parent != NULL)
+            this->parent->set(ui::element::child,
+                              ui::child::focused,
+                              (ui::widget *)NULL);
     }
 }
 
@@ -444,7 +448,8 @@ void ui::composite::mouse_btn_callback(ui::btn_call_data& call_data)
                     : ui::callback::btn_down);
     ui::widget *w = this->tree->search(this->old_pos);
 
-    this->set_focused_child(w);
+    if (which == ui::callback::btn_down)
+        this->set_focused_child(w);
     if (w != NULL)
     {
         glm::ivec2 obj;
@@ -459,11 +464,6 @@ void ui::composite::mouse_btn_callback(ui::btn_call_data& call_data)
     }
     else
         this->call_callbacks(which, &call_data);
-
-    /* w might no longer exist at this position.  Let's search again,
-     * just to make sure.
-     */
-    this->set_focused_child(this->tree->search(this->old_pos));
 }
 
 void ui::composite::key_callback(int key, uint32_t c, int state, int mods)

--- a/composite.h
+++ b/composite.h
@@ -1,6 +1,6 @@
 /* composite.h                                             -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 27 Oct 2019, 22:18:18 tquirk
+ *   last updated 29 Oct 2019, 08:56:57 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -58,8 +58,10 @@ namespace ui
 
         int get_radio_state(bool *) const;
         void set_radio_state(bool);
-        int get_radio_child(GLuint, ui::widget **) const;
-        void set_radio_child(GLuint, ui::widget *);
+        int get_radio_child(ui::widget **) const;
+        void set_radio_child(ui::widget *);
+        int get_focused_child(ui::widget **) const;
+        void set_focused_child(ui::widget *);
         virtual void set_size(GLuint, GLuint) override;
         virtual void set_size(GLuint, const glm::ivec2&) override;
         virtual int get_resize(GLuint, GLuint *) const;
@@ -68,6 +70,8 @@ namespace ui
         virtual int get_pixel_size(GLuint, glm::vec3 *) const;
         virtual int get_state(GLuint, bool *) const;
         virtual void set_state(GLuint, bool);
+        virtual int get_child(GLuint, ui::widget **) const;
+        virtual void set_child(GLuint, ui::widget *);
 
         virtual void set_desired_size(void);
 
@@ -78,8 +82,6 @@ namespace ui
         void clear_removed_children(void);
 
         void child_motion(widget *, GLuint, glm::ivec2&);
-
-        void set_focused_child(widget *);
 
         static void focus_callback(active *, void *, void *);
 

--- a/composite.h
+++ b/composite.h
@@ -1,6 +1,6 @@
 /* composite.h                                             -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 03 Nov 2019, 08:35:59 tquirk
+ *   last updated 03 Nov 2019, 09:51:59 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -83,6 +83,8 @@ namespace ui
         void clear_removed_children(void);
 
         void child_motion(widget *, GLuint, glm::ivec2&);
+
+        void focus_child(std::list<widget *>::iterator);
 
         static void focus_callback(active *, void *, void *);
 

--- a/composite.h
+++ b/composite.h
@@ -1,6 +1,6 @@
 /* composite.h                                             -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Oct 2019, 08:56:57 tquirk
+ *   last updated 03 Nov 2019, 08:35:59 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -47,12 +47,13 @@ namespace ui
       protected:
         composite *parent;
         std::list<widget *> children, to_remove;
+        std::list<widget *>::iterator focused;
         quadtree *tree;
         GLuint resize;
         bool dirty, radio_box;
 
         glm::ivec2 old_pos;
-        widget *focused, *old_child;
+        widget *old_child;
 
         const static int tree_max_depth;
 

--- a/composite.h
+++ b/composite.h
@@ -1,6 +1,6 @@
 /* composite.h                                             -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 14 Aug 2019, 08:17:27 tquirk
+ *   last updated 27 Oct 2019, 22:18:18 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -52,7 +52,7 @@ namespace ui
         bool dirty, radio_box;
 
         glm::ivec2 old_pos;
-        widget *old_child;
+        widget *focused, *old_child;
 
         const static int tree_max_depth;
 
@@ -78,6 +78,10 @@ namespace ui
         void clear_removed_children(void);
 
         void child_motion(widget *, GLuint, glm::ivec2&);
+
+        void set_focused_child(widget *);
+
+        static void focus_callback(active *, void *, void *);
 
         void init(composite *);
 

--- a/composite.h
+++ b/composite.h
@@ -1,6 +1,6 @@
 /* composite.h                                             -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 03 Nov 2019, 09:51:59 tquirk
+ *   last updated 03 Nov 2019, 10:07:44 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -85,6 +85,8 @@ namespace ui
         void child_motion(widget *, GLuint, glm::ivec2&);
 
         void focus_child(std::list<widget *>::iterator);
+        void focus_next_child(void);
+        void focus_previous_child(void);
 
         static void focus_callback(active *, void *, void *);
 

--- a/doc/ui::active.md
+++ b/doc/ui::active.md
@@ -44,8 +44,8 @@ points for widgets.
 
 A *callback list* is a set of functions which are called in response
 to some event.  Events which the `ui::active` recognizes are *enter*,
-*leave*, *motion*, *btn_down*, *btn_up*, *key_down*, *key_up*, and
-*resize*.
+*leave*, *motion*, *btn_down*, *btn_up*, *key_down*, *key_up*,
+*resize*, and *focus*.
 
 Callback functions receive a *call_data* argument, which contains data
 relevant to the individual event.  For example, a *motion* event will
@@ -91,6 +91,7 @@ invocations of the same function, with varying, or even the same,
   | ui::callback::key_down |
   | ui::callback::key_up   |
   | ui::callback::resize   |
+  | ui::callback::focus    |
 
 * `ui::mouse_call_data`
 
@@ -158,6 +159,20 @@ invocations of the same function, with varying, or even the same,
 
   The *resize* callbacks are mostly meant for handling resizes in the
   top-level UI context, but could be used in other widgets.
+
+* `ui::focus_call_data`
+
+  The call-data structure which is passed to *focus* callback
+  functions.
+
+  ```cpp
+  struct {
+      bool focus;
+  }
+  ```
+
+  The *focus* callbacks are informed only of whether focus is in or
+  out of the widget.
 
 ## TIMEOUTS ##
 

--- a/test/run-uitest
+++ b/test/run-uitest
@@ -85,10 +85,10 @@ sub interact_with_text_field
     $status = SendKeys('some more text');
     ok($status, "$test: inserted text at beginning");
     # Try out moving focus via keyboard
-    $status = SendKeys("\t");
-    ok($status, "$test: sent a tab");
-    $status = SendKeys("+(\t)");
-    ok($status, "$test: sent a shift-tab");
+    $status = SendKeys("\t\t\t");
+    ok($status, "$test: sent some tabs");
+    $status = SendKeys("+(\t\t\t)");
+    ok($status, "$test: sent some shift-tabs");
 }
 
 sub interact_with_pie_menu

--- a/test/run-uitest
+++ b/test/run-uitest
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More 'tests' => 74;
+use Test::More 'tests' => 79;
 
 use X11::GUITest qw(:ALL :CONST);
 
@@ -43,6 +43,8 @@ sub interact_with_button
     ok($status, "$test: released button 1");
     $status = ClickWindow($uitest, $loc_x, $loc_y, M_BTN2);
     ok($status, "$test: clicked button 2");
+    $status = SendKeys(' ');
+    ok($status, "$test: clicked button with space");
 }
 
 sub interact_with_row_column

--- a/test/run-uitest
+++ b/test/run-uitest
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More 'tests' => 72;
+use Test::More 'tests' => 74;
 
 use X11::GUITest qw(:ALL :CONST);
 
@@ -84,6 +84,11 @@ sub interact_with_text_field
     ok($status, "$test: beginning of string");
     $status = SendKeys('some more text');
     ok($status, "$test: inserted text at beginning");
+    # Try out moving focus via keyboard
+    $status = SendKeys("\t");
+    ok($status, "$test: sent a tab");
+    $status = SendKeys("+(\t)");
+    ok($status, "$test: sent a shift-tab");
 }
 
 sub interact_with_pie_menu

--- a/test/run-uitest
+++ b/test/run-uitest
@@ -66,8 +66,8 @@ sub interact_with_text_field
     my ($x, $y) = GetWindowPos($uitest);
     ok(defined $x, "$test: x pos is defined");
     ok(defined $y, "$test: y pos is defined");
-    my $status = MoveMouseAbs($x + 265, $y + 140);
-    ok($status, "$test: moved mouse to text field");
+    my $status = ClickWindow($uitest, $x + 265, $y + 140, M_BTN1);
+    ok($status, "$test: clicked in text field");
     $status = SendKeys('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ');
     ok($status, "$test: lots of text");
     $status = SendKeys('{LEF}' x 62);
@@ -137,8 +137,10 @@ sub close_window
     my $test = 'close';
 
     my ($x, $y, $width, $height, $borderWidth) = GetWindowPos($uitest);
-    my $status = MoveMouseAbs($x + $borderWidth + 1, $y + $borderWidth + 1);
-    ok($status, "$test: moved mouse to upper left");
+    my $status = ClickWindow($uitest,
+                             $x + $borderWidth + 1,
+                             $y + $borderWidth + 1);
+    ok($status, "$test: clicked mouse in upper left");
 
     $status = SendKeys('{ESC}');
     ok($status, "$test: escape key sent");

--- a/test/t_active.cc
+++ b/test/t_active.cc
@@ -17,6 +17,7 @@ class test_active : public ui::active
     using ui::active::key_down_cb;
     using ui::active::key_up_cb;
     using ui::active::resize_cb;
+    using ui::active::focus_cb;
     using ui::active::timeout_func;
     using ui::active::timeout_arg;
 
@@ -155,6 +156,9 @@ void test_which_callback(void)
     a->add_callback(ui::callback::resize, fake_callback, NULL);
     is(a->resize_cb.size(), 1, test + "picked resize");
 
+    a->add_callback(ui::callback::focus, fake_callback, NULL);
+    is(a->focus_cb.size(), 1, test + "picked focus");
+
     a->add_callback(99999, fake_callback, NULL);
     is(a->btn_down_cb.size(), 2, test + "default picked btn_down");
 
@@ -221,7 +225,7 @@ void test_timeout(void)
 
 int main(int argc, char **argv)
 {
-    plan(28);
+    plan(29);
 
     test_create_delete();
     test_callback();

--- a/text_field.cc
+++ b/text_field.cc
@@ -1,6 +1,6 @@
 /* text_field.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 31 Aug 2019, 09:05:58 tquirk
+ *   last updated 27 Oct 2019, 15:21:49 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -124,20 +124,17 @@ void ui::text_field::set_image(GLuint t, const ui::image& v)
     /* Don't do anything; this doesn't make sense in this widget. */
 }
 
-void ui::text_field::enter_callback(ui::active *a, void *call, void *client)
+void ui::text_field::focus_callback(ui::active *a, void *call, void *client)
 {
     ui::text_field *t = dynamic_cast<ui::text_field *>(a);
 
     if (t != NULL)
-        t->activate_cursor();
-}
-
-void ui::text_field::leave_callback(ui::active *a, void *call, void *client)
-{
-    ui::text_field *t = dynamic_cast<ui::text_field *>(a);
-
-    if (t != NULL)
-        t->deactivate_cursor();
+    {
+        if (((ui::focus_call_data *)call)->focus == true)
+            t->activate_cursor();
+        else
+            t->deactivate_cursor();
+    }
 }
 
 void ui::text_field::key_down_callback(ui::active *a, void *call, void *client)
@@ -539,11 +536,8 @@ void ui::text_field::init(ui::composite *c)
     glVertexAttribPointer(texture_attr, 2, GL_FLOAT, GL_FALSE,
                           sizeof(float) * 8, (void *)(sizeof(float) * 6));
 
-    this->add_callback(ui::callback::enter,
-                       ui::text_field::enter_callback,
-                       NULL);
-    this->add_callback(ui::callback::leave,
-                       ui::text_field::leave_callback,
+    this->add_callback(ui::callback::focus,
+                       ui::text_field::focus_callback,
                        NULL);
     this->add_callback(ui::callback::key_down,
                        ui::text_field::key_down_callback,

--- a/text_field.h
+++ b/text_field.h
@@ -1,6 +1,6 @@
 /* text_field.h                                            -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 31 Jul 2019, 06:36:37 tquirk
+ *   last updated 27 Oct 2019, 08:31:54 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -61,8 +61,7 @@ namespace ui
         virtual void set_string(GLuint, const std::string&) override;
         virtual void set_image(GLuint, const ui::image&) final;
 
-        static void enter_callback(active *, void *, void *);
-        static void leave_callback(active *, void *, void *);
+        static void focus_callback(active *, void *, void *);
         static void key_down_callback(active *, void *, void *);
         static void key_up_callback(active *, void *, void *);
         static void key_timeout(active *, void *);

--- a/toggle.cc
+++ b/toggle.cc
@@ -1,6 +1,6 @@
 /* toggle.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 12 Aug 2019, 08:25:19 tquirk
+ *   last updated 29 Oct 2019, 05:32:16 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -213,9 +213,13 @@ void ui::toggle::init(ui::composite *c)
      * intercept the active/armed states before the armable might
      * change them.
      */
-    this->remove_callback(ui::callback::btn_up, ui::armable::disarm, NULL);
+    this->remove_callback(ui::callback::btn_up,
+                          ui::armable::mouse_up_callback,
+                          NULL);
     this->add_callback(ui::callback::btn_up, ui::toggle::check, NULL);
-    this->add_callback(ui::callback::btn_up, ui::armable::disarm, NULL);
+    this->add_callback(ui::callback::btn_up,
+                       ui::armable::mouse_up_callback,
+                       NULL);
 }
 
 ui::toggle::toggle(ui::composite *c)

--- a/ui_defs.h
+++ b/ui_defs.h
@@ -1,6 +1,6 @@
 /* ui_defs.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 11 Aug 2019, 21:51:44 tquirk
+ *   last updated 29 Oct 2019, 08:05:41 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -242,7 +242,7 @@ namespace ui
 
     namespace child
     {
-        const GLuint radio = 1;
+        const GLuint radio = 1, focused = 2;
     }
 }
 

--- a/ui_defs.h
+++ b/ui_defs.h
@@ -71,6 +71,13 @@ namespace ui
     }
     resize_call_data;
 
+    /* Focus callback routines */
+    typedef struct focus_callback_call
+    {
+        bool focus;
+    }
+    focus_call_data;
+
 #define GET_VA template<typename A, typename... Args>                \
                int get(GLuint e, GLuint t, A *v, Args... args) const  \
                {                                                     \
@@ -139,6 +146,7 @@ namespace ui
     {
         const GLuint enter = 1, leave = 2, btn_down = 3, btn_up = 4;
         const GLuint motion = 5, key_down = 6, key_up = 7, resize = 8;
+        const GLuint focus = 9;
     }
 
     namespace mouse


### PR DESCRIPTION
This will resolve issue #4.  Keyboard focus is now largely separate from button activity, though button-down events shift keyboard focus to whatever is under the cursor.