### PR TITLE
Initialize glm::mat4 objects correctly

### DIFF
--- a/text_field.cc
+++ b/text_field.cc
@@ -1,6 +1,6 @@
 /* text_field.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 27 Oct 2019, 15:21:49 tquirk
+ *   last updated 30 Nov 2019, 20:52:29 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -356,7 +356,7 @@ int ui::text_field::get_raw_cursor_pos(void)
 void ui::text_field::set_cursor_transform(int pixel_pos)
 {
     glm::vec3 dest;
-    glm::mat4 new_trans;
+    glm::mat4 new_trans(1.0);
 
     this->parent->get(ui::element::pixel_size, ui::size::all, &dest);
     dest.x *= this->margin[1] + this->border[1] + 1 + pixel_pos;

--- a/ui.cc
+++ b/ui.cc
@@ -1,9 +1,9 @@
 /* ui.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 20 Dec 2018, 08:25:46 tquirk
+ *   last updated 30 Nov 2019, 21:00:07 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2018  Trinity Annabelle Quirk
+ * Copyright (C) 2019  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -86,7 +86,7 @@ int ui::context::get(GLuint e, GLuint t, GLuint *v) const
 
 void ui::context::draw(void)
 {
-    glm::mat4 basic_trans;
+    glm::mat4 basic_trans(1.0f);
 
     glUseProgram(this->shader_pgm);
     for (auto& i : this->children)

--- a/widget.cc
+++ b/widget.cc
@@ -1,6 +1,6 @@
 /* widget.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 05 Oct 2019, 22:02:20 tquirk
+ *   last updated 30 Nov 2019, 20:52:56 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -407,7 +407,7 @@ void ui::widget::recalculate_absolute_pos(void)
 void ui::widget::recalculate_transformation_matrix(void)
 {
     glm::vec3 pixel_sz;
-    glm::mat4 new_trans;
+    glm::mat4 new_trans(1.0f);
 
     this->parent->get(ui::element::pixel_size, ui::size::all, &pixel_sz);
     pixel_sz.x *= this->pos.x;
@@ -530,7 +530,7 @@ void ui::widget::init(ui::composite *c)
 
 ui::widget::widget(ui::composite *c)
     : ui::active::active(0, 0), ui::rect::rect(0, 0),
-      pos(0, 0), relative_pos(0, 0), pos_transform(),
+      pos(0, 0), relative_pos(0, 0), pos_transform(1.0f),
       foreground(1.0f, 1.0f, 1.0f, 1.0f), background(0.5f, 0.5f, 0.5f, 1.0f)
 {
     this->init(c);
@@ -631,7 +631,7 @@ void ui::widget::draw(GLuint trans_uniform, const glm::mat4& parent_trans)
 
     if (this->visible == true)
     {
-        glm::mat4 trans = pos_transform * parent_trans;
+        glm::mat4 trans = this->pos_transform * parent_trans;
 
         glBindVertexArray(this->vao);
         glBindBuffer(GL_ARRAY_BUFFER, this->vbo);


### PR DESCRIPTION
Newer versions of GLM change the way they initialize their matrices
in that they just zero them out completely.  The proper way to
initialize them to the identity matrix (which is generally what we
want) is to give them a single 1.0f argument.  This is supposed to
be backward compatible with older versions of GLM, so we shouldn't
be causing any trouble for the zero people who use this toolkit.

Fortunately, we only have a few instances of glm::mat4, so this
change is small and relatively painless.

Ref:  https://github.com/g-truc/glm/issues/809