### PR TITLE
Clean up ui_defs.h includes

### DIFF
--- a/active.cc
+++ b/active.cc
@@ -1,9 +1,9 @@
 /* active.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 25 Jan 2019, 22:07:36 tquirk
+ *   last updated 28 Nov 2020, 10:31:29 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -27,7 +27,6 @@
  *
  */
 
-#include "ui_defs.h"
 #include "active.h"
 
 const ui::to_point zero_time(std::chrono::seconds(0));

--- a/armable.cc
+++ b/armable.cc
@@ -1,9 +1,9 @@
 /* armable.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 03 Nov 2019, 16:20:31 tquirk
+ *   last updated 28 Nov 2020, 10:31:56 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -31,7 +31,6 @@
  *
  */
 
-#include "ui_defs.h"
 #include "armable.h"
 
 int ui::armable::get_state(GLuint t, bool *v) const

--- a/button.cc
+++ b/button.cc
@@ -1,9 +1,9 @@
 /* button.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 26 Dec 2018, 12:12:36 tquirk
+ *   last updated 28 Nov 2020, 10:32:15 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2018  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -32,7 +32,6 @@
 
 #include <algorithm>
 
-#include "ui_defs.h"
 #include "button.h"
 
 void ui::button::set_margin(GLuint s, GLuint v)

--- a/composite.h
+++ b/composite.h
@@ -1,9 +1,9 @@
 /* composite.h                                             -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 03 Nov 2019, 10:07:44 tquirk
+ *   last updated 28 Nov 2020, 10:32:48 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -32,7 +32,6 @@
 
 #include <list>
 
-#include "ui_defs.h"
 #include "active.h"
 #include "quadtree.h"
 #include "widget.h"

--- a/connect_glfw.cc
+++ b/connect_glfw.cc
@@ -1,6 +1,6 @@
 /* connect_glfw.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 05 Aug 2019, 08:59:35 tquirk
+ *   last updated 28 Nov 2020, 10:38:28 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -27,7 +27,6 @@
  *
  */
 
-#include "ui_defs.h"
 #include "connect_glfw.h"
 
 #include <map>

--- a/label.cc
+++ b/label.cc
@@ -1,9 +1,9 @@
 /* label.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Nov 2019, 15:25:27 tquirk
+ *   last updated 28 Nov 2020, 10:33:14 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -34,7 +34,6 @@
 
 #include <glm/gtc/type_ptr.hpp>
 
-#include "ui_defs.h"
 #include "label.h"
 #include "util.h"
 

--- a/pie_menu.cc
+++ b/pie_menu.cc
@@ -1,9 +1,9 @@
 /* pie_menu.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 20 Nov 2019, 08:05:27 tquirk
+ *   last updated 28 Nov 2020, 10:33:28 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -34,7 +34,6 @@
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/geometric.hpp>
 
-#include "ui_defs.h"
 #include "ui.h"
 #include "pie_menu.h"
 

--- a/rect.cc
+++ b/rect.cc
@@ -1,9 +1,9 @@
 /* rect.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 20 Dec 2018, 07:56:20 tquirk
+ *   last updated 28 Nov 2020, 10:34:35 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2018  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -27,7 +27,6 @@
  *
  */
 
-#include "ui_defs.h"
 #include "rect.h"
 
 int ui::rect::get_size(GLuint t, GLuint *v) const

--- a/rect.h
+++ b/rect.h
@@ -1,9 +1,9 @@
 /* rect.h                                                  -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 20 Dec 2018, 07:48:37 tquirk
+ *   last updated 28 Nov 2020, 10:30:54 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2018  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -33,6 +33,8 @@
 #include <GL/gl.h>
 
 #include <glm/vec2.hpp>
+
+#include "ui_defs.h"
 
 namespace ui
 {

--- a/row_column.cc
+++ b/row_column.cc
@@ -1,9 +1,9 @@
 /* row_column.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 20 Dec 2018, 08:15:57 tquirk
+ *   last updated 28 Nov 2020, 10:34:50 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2018  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -29,7 +29,6 @@
 
 #include <algorithm>
 
-#include "ui_defs.h"
 #include "row_column.h"
 
 int ui::row_column::get_size(GLuint t, GLuint *v) const

--- a/test/t_active.cc
+++ b/test/t_active.cc
@@ -2,7 +2,6 @@
 
 using namespace TAP;
 
-#include "../ui_defs.h"
 #include "../active.h"
 
 class test_active : public ui::active

--- a/test/t_rect.cc
+++ b/test/t_rect.cc
@@ -2,7 +2,6 @@
 
 using namespace TAP;
 
-#include "../ui_defs.h"
 #include "../rect.h"
 
 class test_rect : public ui::rect

--- a/text_field.cc
+++ b/text_field.cc
@@ -1,9 +1,9 @@
 /* text_field.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 30 Nov 2019, 20:52:29 tquirk
+ *   last updated 28 Nov 2020, 10:37:24 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -33,7 +33,6 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
-#include "ui_defs.h"
 #include "text_field.h"
 
 int ui::text_field::get_size(GLuint t, GLuint *v) const

--- a/toggle.cc
+++ b/toggle.cc
@@ -1,9 +1,9 @@
 /* toggle.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 29 Oct 2019, 05:32:16 tquirk
+ *   last updated 28 Nov 2020, 10:35:03 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,7 +28,6 @@
  *
  */
 
-#include "ui_defs.h"
 #include "toggle.h"
 
 int ui::toggle::get_state(GLuint t, bool *v) const

--- a/ui.h
+++ b/ui.h
@@ -1,9 +1,9 @@
 /* ui.h                                                    -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 20 Dec 2018, 08:07:32 tquirk
+ *   last updated 28 Nov 2020, 10:35:21 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2018  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -32,7 +32,6 @@
 #ifndef __INC_CUDDLY_UI_H__
 #define __INC_CUDDLY_UI_H__
 
-#include "ui_defs.h"
 #include "composite.h"
 
 namespace ui

--- a/widget.cc
+++ b/widget.cc
@@ -1,9 +1,9 @@
 /* widget.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 30 Nov 2019, 20:52:56 tquirk
+ *   last updated 28 Nov 2020, 10:35:50 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -33,7 +33,6 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
-#include "ui_defs.h"
 #include "widget.h"
 
 const float ui::vertex_buffer::no_texture = -1000.0;

--- a/widget.h
+++ b/widget.h
@@ -1,9 +1,9 @@
 /* widget.h                                                -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 05 Oct 2019, 21:57:17 tquirk
+ *   last updated 28 Nov 2020, 10:36:05 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2020  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -36,7 +36,6 @@
 #include <glm/vec4.hpp>
 #include <glm/mat4x4.hpp>
 
-#include "ui_defs.h"
 #include "active.h"
 #include "composite.h"
 


### PR DESCRIPTION
In trying to include only active.h within an r9client file, we found
that we had to include ui_defs.h first to pull in the GET_VA and
SET_VA macros.  The rect.h file uses those two macros, and is the base
for everything else in the widget set, so we should be able to resolve
the problem once and for all, in that single place.

We've included ui_defs.h directly in the bulk of the .cc files
throughout the widget set, and since rect.h is included everywhere, we
can drop those redundant includes.  It might speed up building by a
microscopic bit?  A couple of the test files also get to drop their
extraneous includes.

Re:  issue #89