### PR TITLE
Decouple char from key

### DIFF
--- a/connect_glfw.cc
+++ b/connect_glfw.cc
@@ -1,9 +1,9 @@
 /* connect_glfw.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 28 Nov 2020, 10:38:28 tquirk
+ *   last updated 17 Jan 2021, 10:31:18 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -39,9 +39,16 @@
 static int global_auto_repeat = 0;
 #endif /* USING X11 */
 
+#include "text_field.h"
+
 static int convert_glfw_mods(int);
+
 void key_callback(GLFWwindow *, int, int, int, int);
+void text_field_focus_hook(bool);
+static GLFWwindow *focus_window = NULL;
+static bool text_field_focus = false;
 void char_callback(GLFWwindow *, unsigned int, int);
+
 void mouse_position_callback(GLFWwindow *, double, double);
 void mouse_button_callback(GLFWwindow *, int, int, int);
 void window_size_callback(GLFWwindow *, int, int);
@@ -193,16 +200,19 @@ void ui_connect_glfw(ui::context *ctx, GLFWwindow *w)
 #endif /* USING_X11 */
 
     glfwSetKeyCallback(w, key_callback);
-    glfwSetCharModsCallback(w, char_callback);
     glfwSetMouseButtonCallback(w, mouse_button_callback);
     glfwSetCursorPosCallback(w, mouse_position_callback);
     glfwSetWindowSizeCallback(w, window_size_callback);
     glfwSetWindowFocusCallback(w, focus_callback);
     glfwSetWindowCloseCallback(w, close_callback);
+
+    ui::text_field::focus_hook = &text_field_focus_hook;
+    focus_window = w;
 }
 
 void ui_disconnect_glfw(ui::context *ctx, GLFWwindow *w)
 {
+    ui::text_field::focus_hook = NULL;
     close_callback(w);
 }
 
@@ -229,11 +239,21 @@ void key_callback(GLFWwindow *w, int key, int scan, int action, int mods)
     ui_state = glfw_key_map[action];
     ui_mods = convert_glfw_mods(mods);
 
-    /* Only deal with non-printing characters and key-up events here.
-     * The char_callback will handle key-down for printing chars.
+    /* Only deal with non-printing characters and key-up events here
+     * when the char_callback is active.
      */
-    if (ui_state == ui::key::up || ui_key > ui::key::non_printing)
+    if (text_field_focus == false
+        || (ui_state == ui::key::up || ui_key > ui::key::non_printing))
         context->key_callback(ui_key, 0, ui_state, ui_mods);
+}
+
+void text_field_focus_hook(bool focus)
+{
+    if (focus == true)
+        glfwSetCharModsCallback(focus_window, char_callback);
+    else
+        glfwSetCharModsCallback(focus_window, NULL);
+    text_field_focus = focus;
 }
 
 void char_callback(GLFWwindow *w, unsigned int c, int mods)

--- a/connect_glfw.cc
+++ b/connect_glfw.cc
@@ -1,6 +1,6 @@
 /* connect_glfw.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 17 Jan 2021, 10:31:18 tquirk
+ *   last updated 17 Jan 2021, 10:54:41 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2021  Trinity Annabelle Quirk
@@ -47,7 +47,7 @@ void key_callback(GLFWwindow *, int, int, int, int);
 void text_field_focus_hook(bool);
 static GLFWwindow *focus_window = NULL;
 static bool text_field_focus = false;
-void char_callback(GLFWwindow *, unsigned int, int);
+void char_callback(GLFWwindow *, unsigned int);
 
 void mouse_position_callback(GLFWwindow *, double, double);
 void mouse_button_callback(GLFWwindow *, int, int, int);
@@ -250,17 +250,15 @@ void key_callback(GLFWwindow *w, int key, int scan, int action, int mods)
 void text_field_focus_hook(bool focus)
 {
     if (focus == true)
-        glfwSetCharModsCallback(focus_window, char_callback);
+        glfwSetCharCallback(focus_window, char_callback);
     else
-        glfwSetCharModsCallback(focus_window, NULL);
+        glfwSetCharCallback(focus_window, NULL);
     text_field_focus = focus;
 }
 
-void char_callback(GLFWwindow *w, unsigned int c, int mods)
+void char_callback(GLFWwindow *w, unsigned int c)
 {
-    int ui_mods = convert_glfw_mods(mods);
-
-    context->key_callback(ui::key::no_key, c, ui::key::down, ui_mods);
+    context->key_callback(ui::key::no_key, c, ui::key::down, 0);
 }
 
 void mouse_position_callback(GLFWwindow *w, double xpos, double ypos)

--- a/text_field.cc
+++ b/text_field.cc
@@ -1,9 +1,9 @@
 /* text_field.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 28 Nov 2020, 10:37:24 tquirk
+ *   last updated 17 Jan 2021, 09:00:32 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2020  Trinity Annabelle Quirk
+ * Copyright (C) 2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -239,7 +239,7 @@ void ui::text_field::set_secondary_repeat(GLuint v)
 
 void ui::text_field::apply_key(const ui::key_call_data *c)
 {
-    if (c->key == ui::key::no_key && c->character != 0)
+    if (c->character != 0)
         this->insert_char(c->character);
     else
         switch (c->key)

--- a/text_field.cc
+++ b/text_field.cc
@@ -1,6 +1,6 @@
 /* text_field.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 17 Jan 2021, 09:00:32 tquirk
+ *   last updated 17 Jan 2021, 10:01:31 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2021  Trinity Annabelle Quirk
@@ -34,6 +34,8 @@
 #include <glm/gtc/type_ptr.hpp>
 
 #include "text_field.h"
+
+void (*ui::text_field::focus_hook)(bool) = NULL;
 
 int ui::text_field::get_size(GLuint t, GLuint *v) const
 {
@@ -130,9 +132,17 @@ void ui::text_field::focus_callback(ui::active *a, void *call, void *client)
     if (t != NULL)
     {
         if (((ui::focus_call_data *)call)->focus == true)
+        {
+            if (ui::text_field::focus_hook != NULL)
+                (*ui::text_field::focus_hook)(true);
             t->activate_cursor();
+        }
         else
+        {
             t->deactivate_cursor();
+            if (ui::text_field::focus_hook != NULL)
+                (*ui::text_field::focus_hook)(false);
+        }
     }
 }
 

--- a/text_field.h
+++ b/text_field.h
@@ -1,9 +1,9 @@
 /* text_field.h                                            -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 27 Oct 2019, 08:31:54 tquirk
+ *   last updated 17 Jan 2021, 09:59:19 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
- * Copyright (C) 2019  Trinity Annabelle Quirk
+ * Copyright (C) 2021  Trinity Annabelle Quirk
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -119,6 +119,8 @@ namespace ui
         SET_VA;
 
         virtual void draw(GLuint, const glm::mat4&) override;
+
+        static void (*focus_hook)(bool);
     };
 }
 


### PR DESCRIPTION
This enables us to use printing keys as "just a key" under GLFW for purposes of key callbacks.