### PR TITLE
Move resize resources from composite to manager

### DIFF
--- a/composite.cc
+++ b/composite.cc
@@ -1,6 +1,6 @@
 /* composite.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 03 Nov 2019, 15:25:43 tquirk
+ *   last updated 25 Dec 2023, 21:04:41 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -126,18 +126,6 @@ void ui::composite::set_size(GLuint d, const glm::ivec2& v)
     call_data.new_size = this->dim;
     for (auto i : this->children)
         i->call_callbacks(ui::callback::resize, &call_data);
-}
-
-int ui::composite::get_resize(GLuint t, GLuint *v) const
-{
-    *v = this->resize;
-    return 0;
-}
-
-void ui::composite::set_resize(GLuint t, GLuint v)
-{
-    if (v <= ui::resize::all)
-        this->resize = v;
 }
 
 int ui::composite::get_pixel_size(GLuint t, float *v) const
@@ -337,16 +325,6 @@ ui::composite::~composite()
     this->children.clear();
 }
 
-int ui::composite::get(GLuint e, GLuint t, GLuint *v) const
-{
-    switch (e)
-    {
-      case ui::element::size:        return this->get_size(t, v);
-      case ui::element::resize:      return this->get_resize(t, v);
-      default:                       return 1;
-    }
-}
-
 int ui::composite::get(GLuint e, GLuint t, float *v) const
 {
     if (e == ui::element::pixel_size)
@@ -373,15 +351,6 @@ int ui::composite::get(GLuint e, GLuint t, ui::widget **v) const
     if (e == ui::element::child)
         return this->get_child(t, v);
     return 1;
-}
-
-void ui::composite::set(GLuint e, GLuint t, GLuint v)
-{
-    switch (e)
-    {
-      case ui::element::size:    this->set_size(t, v);    break;
-      case ui::element::resize:  this->set_resize(t, v);  break;
-    }
 }
 
 void ui::composite::set(GLuint e, GLuint t, bool v)

--- a/composite.h
+++ b/composite.h
@@ -1,6 +1,6 @@
 /* composite.h                                             -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 28 Nov 2020, 10:32:48 tquirk
+ *   last updated 25 Dec 2023, 21:04:42 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2020  Trinity Annabelle Quirk
@@ -48,7 +48,6 @@ namespace ui
         std::list<widget *> children, to_remove;
         std::list<widget *>::iterator focused;
         quadtree *tree;
-        GLuint resize;
         bool dirty, radio_box;
 
         glm::ivec2 old_pos;
@@ -64,8 +63,6 @@ namespace ui
         void set_focused_child(ui::widget *);
         virtual void set_size(GLuint, GLuint) override;
         virtual void set_size(GLuint, const glm::ivec2&) override;
-        virtual int get_resize(GLuint, GLuint *) const;
-        virtual void set_resize(GLuint, GLuint);
         virtual int get_pixel_size(GLuint, float *) const;
         virtual int get_pixel_size(GLuint, glm::vec3 *) const;
         virtual int get_state(GLuint, bool *) const;
@@ -103,13 +100,11 @@ namespace ui
         virtual ~composite();
 
         using ui::rect::get;
-        virtual int get(GLuint, GLuint, GLuint *) const override;
         virtual int get(GLuint, GLuint, float *) const;
         virtual int get(GLuint, GLuint, glm::vec3 *) const;
         virtual int get(GLuint, GLuint, bool *) const;
         virtual int get(GLuint, GLuint, ui::widget **) const;
         using ui::rect::set;
-        virtual void set(GLuint, GLuint, GLuint) override;
         virtual void set(GLuint, GLuint, bool);
         virtual void set(GLuint, GLuint, ui::widget *);
 

--- a/manager.cc
+++ b/manager.cc
@@ -1,6 +1,6 @@
 /* manager.cc
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 06 Oct 2019, 07:19:16 tquirk
+ *   last updated 25 Dec 2023, 21:04:38 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -80,10 +80,19 @@ void ui::manager::set_child_spacing(GLuint t, const glm::ivec2& v)
     }
 }
 
+int ui::manager::get_resize(GLuint t, GLuint *v) const
+{
+    *v = this->resize;
+    return 0;
+}
+
 void ui::manager::set_resize(GLuint t, GLuint v)
 {
-    this->composite::set_resize(t, v);
-    this->set_desired_size();
+    if (v <= ui::resize::all)
+    {
+        this->resize = v;
+        this->set_desired_size();
+    }
 }
 
 int ui::manager::get_size(GLuint t, GLuint *v) const
@@ -236,7 +245,7 @@ int ui::manager::get(GLuint e, GLuint t, GLuint *v) const
             return this->widget::parent->get(e, t, v);
         return 1;
       case ui::element::child_spacing:  return this->get_child_spacing(t, v);
-      case ui::element::resize:         return this->composite::get(e, t, v);
+      case ui::element::resize:         return this->get_resize(t, v);
       default:                          return this->widget::get(e, t, v);
     }
     return 1;
@@ -261,7 +270,7 @@ void ui::manager::set(GLuint e, GLuint t, GLuint v)
     switch (e)
     {
       case ui::element::child_spacing:  this->set_child_spacing(t, v);  break;
-      case ui::element::resize:         this->composite::set(e, t, v);  break;
+      case ui::element::resize:         this->set_resize(t, v);         break;
       default:                          this->widget::set(e, t, v);     break;
     }
 }

--- a/manager.h
+++ b/manager.h
@@ -1,6 +1,6 @@
 /* manager.h                                               -*- C++ -*-
  *   by Trinity Quirk <tquirk@ymb.net>
- *   last updated 06 Oct 2019, 07:18:41 tquirk
+ *   last updated 26 Dec 2023, 17:31:02 tquirk
  *
  * CuddlyGL OpenGL widget toolkit
  * Copyright (C) 2019  Trinity Annabelle Quirk
@@ -39,13 +39,15 @@ namespace ui
     class manager : public widget, public composite
     {
       protected:
+        GLuint resize;
         glm::ivec2 child_spacing;
 
         int get_child_spacing(GLuint, GLuint *) const;
         int get_child_spacing(GLuint, glm::ivec2 *) const;
         void set_child_spacing(GLuint, GLuint);
         void set_child_spacing(GLuint, const glm::ivec2&);
-        virtual void set_resize(GLuint, GLuint) override;
+        virtual int get_resize(GLuint, GLuint *) const;
+        virtual void set_resize(GLuint, GLuint);
         virtual int get_size(GLuint, GLuint *) const override;
         virtual int get_size(GLuint, glm::ivec2 *) const override;
         virtual void set_size(GLuint, GLuint) override;


### PR DESCRIPTION
The `ui::composite` didn't use any of the `ui::resize::*` resources. The only of its descents which did was the `ui::manager`, so it makes much more sense to support them there.

Ref:  #93